### PR TITLE
chore: update Brewfile and remove unused casks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ git/env.zsh
 git/gitconfig.local.symlink
 git/gitconfig.symlink
 Brewfile.lock.json
+node_modules/

--- a/Brewfile
+++ b/Brewfile
@@ -1,7 +1,6 @@
 cask_args appdir: '/Applications'
 
-tap 'homebrew/bundle'
-tap 'homebrew/services'
+tap "homebrew/services"
 tap 'mongodb/brew'
 tap 'puma/puma'
 

--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -2,7 +2,7 @@
 [include]
         path = ~/.gitconfig.local
 [hub]
-        protocol = https
+        protocol = ssh
 [alias]
         count   = !git shortlog -sn
 	grog = log --graph --abbrev-commit --decorate --all --format=format:\"%C(bold blue)%h%C(reset) - %C(bold cyan)%aD%C(dim white) - %an%C(reset) %C(bold green)(%ar)%C(reset)%C(bold yellow)%d%C(reset)%n %C(white)%s%C(reset)\"
@@ -28,12 +28,10 @@
         #
         # Setting to git 2.0 default to suppress warning message
         default = simple
-[credential]
-	helper = osxkeychain
 [user]
 	name = Tony Kornmeier
 	email = akornmeier@users.noreply.github.com
-	signingkey = ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHQsyymgxlaMgbAl6cHThMiYuN7ncC9CrmzKnDRu3gav
+	signingkey = ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICKn+EXhdQZhcdTMuQw5Maxe59WBjYIvD473K5ANbO9p
 [gpg]
         format = ssh
 [gpg "ssh"]

--- a/node_modules/.pnpm-workspace-state.json
+++ b/node_modules/.pnpm-workspace-state.json
@@ -1,5 +1,5 @@
 {
-  "lastValidatedTimestamp": 1742912049422,
+  "lastValidatedTimestamp": 1742925889919,
   "projects": {},
   "pnpmfileExists": false,
   "settings": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": ".dotfiles",
+  "name": "tk-dotfiles",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/script/install
+++ b/script/install
@@ -12,7 +12,7 @@ echo "› Becoming self-aware..."
 
 # Run Homebrew through the Brewfile
 echo "› Install brew bundle..."
-brew bundle
+brew bundle install
 
 # find the installers and run them iteratively
 echo "› Running installer scripts..."

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -110,10 +110,5 @@ eval "$(starship init zsh)"
 # GPG signature
 export GPG_TTY=$(tty)
 
-# pnpm
-export PNPM_HOME="~/Library/pnpm"
-case ":$PATH:" in
-  *":$PNPM_HOME:"*) ;;
-  *) export PATH="$PNPM_HOME:$PATH" ;;
-esac
-# pnpm end
+# 1Password SSH Client
+export SSH_AUTH_SOCK=~/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agent.sock


### PR DESCRIPTION
This pull request includes various updates and improvements to configuration files and scripts. The most important changes are grouped by theme below:

### Configuration Updates:

* [`git/gitconfig.symlink`](diffhunk://#diff-d8c44643417883373684db54c72f9a5eca13b0b46fa7898555c9b9d227ba87b3L5-R5): Changed the `hub` protocol from `https` to `ssh` and updated the `signingkey` to a new SSH key. Removed the `credential` helper for `osxkeychain`. [[1]](diffhunk://#diff-d8c44643417883373684db54c72f9a5eca13b0b46fa7898555c9b9d227ba87b3L5-R5) [[2]](diffhunk://#diff-d8c44643417883373684db54c72f9a5eca13b0b46fa7898555c9b9d227ba87b3L31-R34)

### Script Improvements:

* [`script/install`](diffhunk://#diff-14b680935f42f2ba5b32d6c65ac9daf4d6cd4c1f3f7434bfc9efc8ecf5f5e183L15-R15): Updated the command to install Homebrew bundles from `brew bundle` to `brew bundle install`.

### File and Path Updates:

* [`zsh/zshrc.symlink`](diffhunk://#diff-4d6850c04c6a1bcc8f4667b8c199a349c1b61f4351c8d04260de56ef05a8894cL113-R114): Removed the `pnpm` configuration and added configuration for the 1Password SSH Client.

### Minor Adjustments:

* [`Brewfile`](diffhunk://#diff-1b33d9c13a9a1b0c5d5bc83697ba7b4d36e6cf45f78184c3a28527ffc4418e2dL3-R3): Changed the quotation style for the `homebrew/services` tap.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R2): Renamed the project from `.dotfiles` to `tk-dotfiles`.