### PR TITLE
feat: adds symlinks for FNM to process MCP commands

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -51,7 +51,7 @@ $DOTFILES/homebrew/install.sh 2>&1
 echo "› brew update"
 brew update
 
-# Upgrade any already-installed formlae
+# Upgrade any already-installed formulae
 echo "› brew upgrade"
 brew upgrade --cask
 

--- a/fnm/install.sh
+++ b/fnm/install.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Installation of FNM happens in BREW
+# This script is used to create or update the symlinks for Node.js, npm, npx, and corepack
+# These symlink allow Claude MCP commands to use the Node.js version managed by FNM (Fast Node Manager)
+
+# Create or update the symlink to the current fnm Node version
+sudo ln -sf /Users/$USER/.local/share/fnm/aliases/default/bin/node /usr/local/bin/node
+sudo ln -sf /Users/$USER/.local/share/fnm/aliases/default/bin/npm /usr/local/bin/npm
+sudo ln -sf /Users/$USER/.local/share/fnm/aliases/default/bin/npx /usr/local/bin/npx
+sudo ln -sf /Users/$USER/.local/share/fnm/aliases/default/bin/corepack /usr/local/bin/corepack
+
+echo "Node.js symlinks updated"
+echo "node: $(node --version)"
+echo "npm: $(npm --version)"
+echo "npx: $(npx --version)"
+echo "corepack: $(corepack --version)"

--- a/fnm/install.sh
+++ b/fnm/install.sh
@@ -5,10 +5,10 @@
 # These symlink allow Claude MCP commands to use the Node.js version managed by FNM (Fast Node Manager)
 
 # Create or update the symlink to the current fnm Node version
-sudo ln -sf /Users/$USER/.local/share/fnm/aliases/default/bin/node /usr/local/bin/node
-sudo ln -sf /Users/$USER/.local/share/fnm/aliases/default/bin/npm /usr/local/bin/npm
-sudo ln -sf /Users/$USER/.local/share/fnm/aliases/default/bin/npx /usr/local/bin/npx
-sudo ln -sf /Users/$USER/.local/share/fnm/aliases/default/bin/corepack /usr/local/bin/corepack
+sudo ln -sf $HOME/.local/share/fnm/aliases/default/bin/node /usr/local/bin/node
+sudo ln -sf $HOME/.local/share/fnm/aliases/default/bin/npm /usr/local/bin/npm
+sudo ln -sf $HOME/.local/share/fnm/aliases/default/bin/npx /usr/local/bin/npx
+sudo ln -sf $HOME/.local/share/fnm/aliases/default/bin/corepack /usr/local/bin/corepack
 
 echo "Node.js symlinks updated"
 echo "node: $(node --version)"

--- a/fnm/install.sh
+++ b/fnm/install.sh
@@ -5,10 +5,10 @@
 # These symlink allow Claude MCP commands to use the Node.js version managed by FNM (Fast Node Manager)
 
 # Create or update the symlink to the current fnm Node version
-sudo ln -sf $HOME/.local/share/fnm/aliases/default/bin/node /usr/local/bin/node
-sudo ln -sf $HOME/.local/share/fnm/aliases/default/bin/npm /usr/local/bin/npm
-sudo ln -sf $HOME/.local/share/fnm/aliases/default/bin/npx /usr/local/bin/npx
-sudo ln -sf $HOME/.local/share/fnm/aliases/default/bin/corepack /usr/local/bin/corepack
+sudo ln -sf "$HOME/.local/share/fnm/aliases/default/bin/node" /usr/local/bin/node
+sudo ln -sf "$HOME/.local/share/fnm/aliases/default/bin/npm" /usr/local/bin/npm
+sudo ln -sf "$HOME/.local/share/fnm/aliases/default/bin/npx" /usr/local/bin/npx
+sudo ln -sf "$HOME/.local/share/fnm/aliases/default/bin/corepack" /usr/local/bin/corepack
 
 echo "Node.js symlinks updated"
 echo "node: $(node --version)"


### PR DESCRIPTION
This pull request introduces a new script, `fnm/install.sh`, to streamline the creation and updating of symlinks for Node.js, npm, npx, and corepack. This ensures that commands relying on Node.js use the version managed by FNM (Fast Node Manager).

Key changes:

### Script addition for symlink management:
* [`fnm/install.sh`](diffhunk://#diff-354d75a9734365e672b1135e072e0e227cfc2681b94b98a195b6091c07c3d695R1-R17): Added a Bash script to automate the creation or updating of symlinks for Node.js tools (`node`, `npm`, `npx`, and `corepack`) to point to the default FNM-managed Node.js version. The script also outputs the versions of the tools for verification.