### PR TITLE
feat: add claude and claude code casks to brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -27,7 +27,7 @@ brew 'readline' # Library for command-line editing
 brew 'redis', restart_service: false # In-memory database (manual start: brew services start redis)
 brew 'starship' # Cross-shell prompt for astronauts
 brew 'tdd-guard' # Test-driven development guard
-brew 'uv' # Cross-platform library for asynchronous I/O
+brew 'uv' # Extremely fast Python package installer and resolver
 brew 'wget' # Internet file retriever
 brew 'zsh-autocomplete' # Zsh plugin that adds tab completion for common commands
 brew 'zsh-autosuggestions' # FISH-like autosuggestions for ZSH

--- a/Brewfile
+++ b/Brewfile
@@ -11,6 +11,7 @@ brew 'gcc' # the GNU Compiler
 brew 'git-delta' # syntax-highlighting pager for git and diff output
 brew 'git' # distributed revision control system
 brew 'go' # go programming language
+brew 'gpg' # GNU Privacy Guard
 brew 'grc' # colorize logfiles and command output
 brew 'fnm' # Node.js version manager and corepack installer
 # NOTE: If any formula installs node as a dependency, it will be removed by fnm/install.sh and bin/dot
@@ -25,6 +26,8 @@ brew 'postgresql', restart_service: false # SQL database (manual start: brew ser
 brew 'readline' # Library for command-line editing
 brew 'redis', restart_service: false # In-memory database (manual start: brew services start redis)
 brew 'starship' # Cross-shell prompt for astronauts
+brew 'tdd-guard' # Test-driven development guard
+brew 'uv' # Cross-platform library for asynchronous I/O
 brew 'wget' # Internet file retriever
 brew 'zsh-autocomplete' # Zsh plugin that adds tab completion for common commands
 brew 'zsh-autosuggestions' # FISH-like autosuggestions for ZSH
@@ -35,10 +38,12 @@ brew 'zsh-syntax-highlighting' # Terminal bliss
 brew 'zsh' # UNIX shell (command interpreter)
 
 cask '1password' # Password manager
+cask 'claude' # AI programming friend
 cask 'claude-code' # AI programming friend
 cask 'discord' # VoIP and chat app
 cask 'firefox' # Web browser
 cask 'font-fira-code-nerd-font' # Monospace font with programming ligatures
+cask 'font-jetbrains-mono-nerd-font' # Monospace font with programming ligatures
 cask 'google-chrome' # Web browser
 cask 'ghostty' # Terminal emulator
 cask 'insomnia' # REST client

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,158 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+This is a macOS dotfiles repository for managing development environment configuration. It uses a topic-based organization where each topic (zsh, git, macos, etc.) contains related configuration files and scripts.
+
+## Core Commands
+
+### Development Workflow
+
+```sh
+# Install dependencies and setup tooling
+pnpm install
+
+# Format code
+pnpm format              # Format all files
+pnpm format:check        # Check formatting without changing files
+
+# Lint code
+pnpm lint                # Run oxlint on all files
+```
+
+### Dotfiles Management
+
+The `dot` command (in `bin/dot`) is the primary tool for managing dotfiles:
+
+```sh
+# Smart updates (default) - only updates what's needed
+dot
+dot update
+
+# First-time setup
+dot bootstrap
+
+# Full installation
+dot install
+
+# Open dotfiles in editor
+dot --edit
+```
+
+### Version Management
+
+This project uses Changesets for version management:
+
+```sh
+pnpm changeset           # Create a new changeset
+pnpm changeset:add       # Same as above
+pnpm changeset:status    # View pending changesets
+pnpm version             # Consume changesets and update version
+pnpm release             # Create git tags for new versions
+```
+
+## Architecture
+
+### Topic-Based Organization
+
+The repository is organized by "topics" (directories), where each topic contains related configuration:
+
+- **bin/**: Executables added to `$PATH` (e.g., `dot`, `e`, `set-defaults`)
+- **zsh/**: Zsh configuration and Oh My Zsh setup
+- **git/**: Git configuration and aliases
+- **macos/**: macOS-specific settings and defaults
+- **fnm/**: Fast Node Manager configuration
+- **functions/**: Reusable shell functions
+- **system/**: System-level configurations (keys, paths)
+
+### File Naming Conventions
+
+Files follow specific naming patterns with automatic behavior:
+
+- **`*.symlink`**: Automatically symlinked to `$HOME` (e.g., `zshrc.symlink` → `~/.zshrc`)
+- **`path.zsh`**: Loaded first, used for setting up `$PATH`
+- **`*.zsh`**: Loaded into environment (aliases, config, completions)
+- **`completion.zsh`**: Loaded last for autocomplete setup
+- **`install.sh`**: Topic-specific installation scripts run during `dot install`
+
+### The `dot` Script
+
+The main orchestration script (`bin/dot`) handles three modes:
+
+1. **`bootstrap`**: First-time setup
+   - Sets up Git configuration (name/email)
+   - Creates symlinks for dotfiles
+   - Installs Homebrew if missing
+   - Prompts to continue with full installation
+
+2. **`install`**: Full installation
+   - Updates symlinks
+   - Installs all Brewfile packages
+   - Runs topic installers (macos, fnm, zsh)
+   - Applies macOS system defaults
+
+3. **`update`** (default): Smart updates
+   - Only updates changed symlinks
+   - Updates Homebrew
+   - Upgrades outdated packages only
+   - Installs missing Brewfile packages
+   - Removes Homebrew's Node (replaced by FNM)
+
+### Symlink Management
+
+Symlinks are created automatically from `*.symlink` files:
+- Files are linked from topics into `$HOME`
+- The script handles conflicts (skip, overwrite, backup)
+- Only changed symlinks are updated during `dot update`
+
+### Node.js Management
+
+Uses FNM (Fast Node Manager) instead of nvm:
+- Node binaries are symlinked to `/usr/local/bin` for system-wide access
+- This enables GUI apps and MCP servers to use Node
+- Homebrew's Node is automatically removed if detected
+- Configured with `--use-on-cd`, `--version-file-strategy=recursive`, and `--corepack-enabled`
+
+## Important Notes
+
+### Brewfile
+
+The Brewfile manages three types of installations:
+1. Brew Taps - service level tasks
+2. Brew formulas - CLI tools (git, gh, fnm, starship, etc.)
+3. Casks - GUI applications (Chrome, Discord, Warp, Zoom, etc.)
+
+**Note**: `mas` (Mac App Store CLI) entries are commented out due to compatibility issues with macOS Sequoia (15.x). These apps must be installed manually through the App Store.
+
+### FNM Node Management
+
+FNM is preferred over Homebrew's Node:
+- Node.js LTS is installed via FNM
+- Symlinks are created for global access (node, npm, npx, corepack)
+- If any formula installs node as a dependency, it's removed by `fnm/install.sh` and `bin/dot`
+
+### macOS Configuration
+
+- `macos/install.sh`: Checks for macOS updates during installation
+- `macos/set-defaults.sh`: Applies system preferences (requires sudo)
+- Both scripts are run during `dot install`
+
+### Scripts vs Bin
+
+- **`script/`**: Legacy bootstrap and install scripts (now handled by `dot`)
+- **`bin/`**: Executables added to `$PATH` for everyday use
+  - `dot`: Main dotfiles management command
+  - `e`: Quick editor launcher (opens in Zed)
+  - `set-defaults`: Applies macOS system defaults
+
+## Testing Changes
+
+When modifying the dotfiles:
+
+1. Test symlink changes: `dot update` (checks symlinks without full install)
+2. Test full installation: `dot install` (runs all installers)
+3. Test Brewfile changes: `brew bundle check` (verify) then `brew bundle install`
+4. Format before committing: `pnpm format`
+5. Create changeset for significant changes: `pnpm changeset`

--- a/bin/e
+++ b/bin/e
@@ -13,4 +13,4 @@
 #   $ e .
 #   $ e /usr/local
 #   # => opens the specified directory in your editor
-exec code "${1:-.}"
+exec zed "${1:-.}"

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -29,6 +29,28 @@ then
   source ~/.localrc
 fi
 
+# OH MY ZSH Settings - Load FIRST so custom configs can override
+
+# Path to your Oh My Zsh installation.
+export ZSH="$HOME/.oh-my-zsh"
+
+# Only load Oh My Zsh if it's installed
+if [[ -d "$ZSH" ]]; then
+  zstyle ':omz:update' mode auto      # update automatically without asking
+  zstyle ':omz:update' frequency 7    # number of days auto update will run
+
+  # Would you like to use another custom folder than $ZSH/custom?
+  ZSH_CUSTOM=$ZSH/custom
+
+  # Which plugins would you like to load?
+  # Standard plugins can be found in $ZSH/plugins/
+  # Custom plugins may be added to $ZSH_CUSTOM/plugins/
+
+  plugins=(aliases bun deno fnm gh z)
+
+  source "$ZSH/oh-my-zsh.sh"
+fi
+
 # all of our zsh files
 typeset -U config_files
 config_files=($DOTFILES/**/*.zsh)
@@ -40,6 +62,7 @@ do
 done
 
 # load everything but the path and completion files
+# These load AFTER Oh My Zsh so they can override OMZ defaults
 for file in ${${config_files:#*/path.zsh}:#*/completion.zsh}
 do
   source $file
@@ -81,28 +104,6 @@ do
 done
 
 unset config_files
-
-# OH MY ZSH Settings
-
-# Path to your Oh My Zsh installation.
-export ZSH="$HOME/.oh-my-zsh"
-
-# Only load Oh My Zsh if it's installed
-if [[ -d "$ZSH" ]]; then
-  zstyle ':omz:update' mode auto      # update automatically without asking
-  zstyle ':omz:update' frequency 7    # number of days auto update will run
-
-  # Would you like to use another custom folder than $ZSH/custom?
-  ZSH_CUSTOM=$ZSH/custom
-
-  # Which plugins would you like to load?
-  # Standard plugins can be found in $ZSH/plugins/
-  # Custom plugins may be added to $ZSH_CUSTOM/plugins/
-
-  plugins=(aliases bun deno fnm gh z)
-
-  source "$ZSH/oh-my-zsh.sh"
-fi
 
 # User configuration
 


### PR DESCRIPTION
This pull request introduces several improvements and additions to the dotfiles repository, focusing on better documentation, enhanced development tooling, and improved shell configuration. The most notable changes include the addition of a comprehensive guide for Claude Code, updates to Homebrew dependencies, and a restructuring of how Oh My Zsh is loaded in the Zsh configuration.

**Documentation and Developer Experience:**

* Added a new `CLAUDE.md` file that provides detailed guidance for using Claude Code with this repository, including an overview of the repository structure, core commands, dotfiles management workflow, and best practices for testing changes.

**Homebrew and Tooling Enhancements:**

* Updated the `Brewfile` to include new CLI tools and GUI applications:
  - Added `gpg` for cryptographic operations.
  - Added `tdd-guard` and `uv` for test-driven development and asynchronous I/O, respectively.
  - Added new casks: `claude`, `font-jetbrains-mono-nerd-font`, and others for improved AI programming and font support.

**Zsh and Oh My Zsh Configuration:**

* Refactored the loading order of Oh My Zsh in `zshrc.symlink` to ensure it is loaded first, allowing custom configurations to override defaults. The Oh My Zsh settings block was moved to the top of the file, and redundant code was removed from the bottom. [[1]](diffhunk://#diff-4d6850c04c6a1bcc8f4667b8c199a349c1b61f4351c8d04260de56ef05a8894cR32-R53) [[2]](diffhunk://#diff-4d6850c04c6a1bcc8f4667b8c199a349c1b61f4351c8d04260de56ef05a8894cR65) [[3]](diffhunk://#diff-4d6850c04c6a1bcc8f4667b8c199a349c1b61f4351c8d04260de56ef05a8894cL85-L106)
* Ensured that custom Zsh configuration files are loaded after Oh My Zsh, maintaining the intended override behavior.

These changes collectively improve the maintainability, clarity, and extensibility of the dotfiles setup, making it easier for both humans and AI tools to work with the repository.