### PR TITLE
fix: mas brew formula updated, fixes install issue on MacOS Tahoe

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -55,10 +55,6 @@ cask 'zed' # Code editor
 cask 'zoom' # Video conferencing software
 
 # Install mas apps
-# mas 'Be Focused',  id: 973134470 # Pomodoro Focus Timer
-# mas 'CopyClip',    id: 595191960 # Clipboard manager
-# mas 'Dato',        id: 1470584107 # Calendar and time zone menu bar app
-# mas 'Hand Mirror', id: 1502839586 # Screen mirroring app
 # mas 'Keycastr',    id: 1058125028 # Keystroke visualizer
-# mas 'Lungo',       id: 1263070803 # Prevents your Mac from going to sleep
-# mas 'Magnet',      id: 441258766 # Window manager
+mas 'Lungo',       id: 1263070803 # Prevents your Mac from going to sleep
+mas 'Magnet',      id: 441258766 # Window manager


### PR DESCRIPTION
This pull request makes a minor update to the `Brewfile`, enabling the installation of the `Lungo` and `Magnet` Mac App Store apps by uncommenting their entries. This change allows these utilities to be installed automatically as part of the setup process.