### PR TITLE
feat(git): add  alias for convenience after a PR is merged

### DIFF
--- a/git/aliases.zsh
+++ b/git/aliases.zsh
@@ -18,3 +18,4 @@ alias gb='git branch'
 alias gs='git status -sb' # upgrade your git if -sb breaks for you. it's fun.
 alias gac='git add -A && git commit -m'
 alias glod='git pull origin develop'
+alias gsync='git pull origin main && pnpm i && pnpm build && pnpm test'


### PR DESCRIPTION
This pull request adds a new convenience alias to the `git/aliases.zsh` file to streamline syncing with the `main` branch and running project setup commands.

New workflow alias:

* Added `gsync` alias to run `git pull origin main` followed by `pnpm i`, `pnpm build`, and `pnpm test` for faster project synchronization and setup.