### PR TITLE
feat(shell): add modern bash and fix gsync compatibility

### DIFF
--- a/.changeset/tangy-views-try.md
+++ b/.changeset/tangy-views-try.md
@@ -1,0 +1,5 @@
+---
+'tk-dotfiles': patch
+---
+
+Update Bash to latest in brewfile

--- a/Brewfile
+++ b/Brewfile
@@ -3,6 +3,7 @@ cask_args appdir: '/Applications'
 tap 'mongodb/brew'
 
 # gnu stuff
+brew 'bash' # Bash 5.x (macOS ships with 3.2)
 brew 'coreutils'
 brew 'findutils'
 

--- a/bin/gsync
+++ b/bin/gsync
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 echo "=== gsync: Syncing with remote ==="


### PR DESCRIPTION
  - Add bash 5.x to Brewfile (macOS ships with 3.2)
  - Update gsync shebang to use env bash (respects PATH)
  - Enables mapfile and other modern bash features