### PR TITLE
fix(dot): handle bash 5.x arithmetic exit codes with set -e

### DIFF
--- a/.changeset/new-chicken-notice.md
+++ b/.changeset/new-chicken-notice.md
@@ -1,0 +1,5 @@
+---
+'tk-dotfiles': patch
+---
+
+fix syntax issue in dot command

--- a/bin/dot
+++ b/bin/dot
@@ -190,10 +190,10 @@ install_dotfiles () {
 
 		# Check if symlink already exists and is correct
 		if [ -L "$dst" ] && [ "$(readlink $dst)" == "$src" ]; then
-			((skipped_count++))
+			((skipped_count++)) || true
 		else
 			link_file "$src" "$dst"
-			((linked_count++))
+			((linked_count++)) || true
 		fi
 	done
 


### PR DESCRIPTION
  - Add || true to ((count++)) operations in install_dotfiles
  - Bash 5.x with set -e treats ((0++)) as failure (returns 0 = falsy)
  - Fixes script termination during symlink checking
  - Audited all other shell scripts - no similar issues found