### PR TITLE
feat(dot): switch tdd-guard from Homebrew to npm global

### DIFF
--- a/.changeset/big-turtles-cough.md
+++ b/.changeset/big-turtles-cough.md
@@ -1,0 +1,5 @@
+---
+'tk-dotfiles': patch
+---
+
+switch tdd-guard from Homebrew to npm global

--- a/Brewfile
+++ b/Brewfile
@@ -28,7 +28,6 @@ brew 'postgresql', restart_service: false # SQL database (manual start: brew ser
 brew 'readline' # Library for command-line editing
 brew 'redis', restart_service: false # In-memory database (manual start: brew services start redis)
 brew 'starship' # Cross-shell prompt for astronauts
-brew 'tdd-guard' # Test-driven development guard
 brew 'uv' # Extremely fast Python package installer and resolver
 brew 'wget' # Internet file retriever
 brew 'zsh-autocomplete' # Zsh plugin that adds tab completion for common commands

--- a/bin/dot
+++ b/bin/dot
@@ -329,6 +329,22 @@ cmd_install() {
 		echo -e "  ${YELLOW}- 📦 npx: $(npx --version)${NC}"
 		echo -e "  ${YELLOW}- 📦 corepack: $(corepack --version)${NC}"
 		echo -e "  ${GREEN}✓ FNM setup complete!${NC}"
+
+		# Install npm global packages
+		echo ""
+		echo -e "${BLUE}📦 Installing npm global packages...${NC}"
+		NPM_GLOBALS=(
+			"tdd-guard"
+		)
+		for pkg in "${NPM_GLOBALS[@]}"; do
+			if npm list -g "$pkg" &>/dev/null; then
+				echo -e "  ${GREEN}✓ $pkg already installed${NC}"
+			else
+				echo "  Installing $pkg..."
+				npm install -g "$pkg"
+				echo -e "  ${GREEN}✓ $pkg installed${NC}"
+			fi
+		done
 	fi
 
 	# Run zsh installer
@@ -421,9 +437,42 @@ cmd_update() {
 	brew cleanup
 	echo -e "  ${GREEN}✓ Cleanup complete${NC}"
 
+	# Update npm global packages (if FNM/Node is available)
+	if command -v npm &> /dev/null; then
+		echo ""
+		echo "============================================================"
+		echo -e "${BLUE}📦 Updating npm global packages...${NC}"
+		echo "============================================================"
+
+		NPM_GLOBALS=(
+			"tdd-guard"
+		)
+		for pkg in "${NPM_GLOBALS[@]}"; do
+			echo ""
+			echo "  Checking $pkg..."
+			# Check if package is installed
+			if npm list -g "$pkg" &>/dev/null; then
+				# Check for updates
+				CURRENT=$(npm list -g "$pkg" --depth=0 2>/dev/null | grep "$pkg" | sed 's/.*@//')
+				LATEST=$(npm view "$pkg" version 2>/dev/null)
+				if [ "$CURRENT" != "$LATEST" ]; then
+					echo "  Updating $pkg ($CURRENT → $LATEST)..."
+					npm install -g "$pkg"
+					echo -e "  ${GREEN}✓ $pkg updated${NC}"
+				else
+					echo -e "  ${GREEN}✓ $pkg is up to date ($CURRENT)${NC}"
+				fi
+			else
+				echo "  Installing $pkg..."
+				npm install -g "$pkg"
+				echo -e "  ${GREEN}✓ $pkg installed${NC}"
+			fi
+		done
+	fi
+
 	echo ""
 	echo "============================================================"
-    echo -e "${GREEN}✅ Installation complete!${NC}"
+    echo -e "${GREEN}✅ Updates complete!${NC}"
     echo "============================================================"
 	echo ""
 	echo "✨ Updates complete!"

--- a/claude/claude_desktop_config.json.template
+++ b/claude/claude_desktop_config.json.template
@@ -2,7 +2,10 @@
   "mcpServers": {
     "sequential-thinking": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-sequential-thinking"
+      ]
     },
     "serena": {
       "command": "uvx",
@@ -13,5 +16,8 @@
         "start-mcp-server"
       ]
     }
+  },
+  "preferences": {
+    "chromeExtensionEnabled": true
   }
 }


### PR DESCRIPTION
- Remove tdd-guard from Brewfile (Homebrew tap)
- Add npm global packages installation to `dot install` after FNM setup
- Add smart version checking and updates to `dot update`
- Use NPM_GLOBALS array for easy extensibility

npm's #!/usr/bin/env node shebang works with fnm, unlike Homebrew's hardcoded Node path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)