### PR TITLE
Chore/alias update

### DIFF
--- a/.changeset/little-rocks-own.md
+++ b/.changeset/little-rocks-own.md
@@ -1,0 +1,5 @@
+---
+'tk-dotfiles': patch
+---
+
+Update brewfile and a claude code alias

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ git/gitconfig.local.symlink
 git/gitconfig.symlink
 Brewfile.lock.json
 node_modules/
+.claude/
+logs/

--- a/Brewfile
+++ b/Brewfile
@@ -25,9 +25,11 @@ brew 'mas' # CLI for installing app from Mac App Store
 brew 'mongodb-community', restart_service: false # NoSQL database (manual start: brew services start mongodb-community)
 brew 'openssl' # Cryptography and SSL/TLS Toolkit
 brew 'postgresql', restart_service: false # SQL database (manual start: brew services start postgresql)
+brew 'pyenv' # Python virtual env
 brew 'readline' # Library for command-line editing
 brew 'redis', restart_service: false # In-memory database (manual start: brew services start redis)
 brew 'starship' # Cross-shell prompt for astronauts
+brew 'tmux' # Terminal multiplexer
 brew 'uv' # Extremely fast Python package installer and resolver
 brew 'wget' # Internet file retriever
 brew 'zsh-autocomplete' # Zsh plugin that adds tab completion for common commands
@@ -41,6 +43,7 @@ brew 'zsh' # UNIX shell (command interpreter)
 cask '1password' # Password manager
 cask 'claude' # AI programming friend
 cask 'claude-code' # AI programming friend
+cask 'cmux' # Ghostty-based terminal with vertical tabs
 cask 'cursor' # Write, edit, and chat about your code with AI
 cask 'discord' # VoIP and chat app
 cask 'firefox' # Web browser
@@ -49,6 +52,7 @@ cask 'font-jetbrains-mono-nerd-font' # Monospace font with programming ligatures
 cask 'google-chrome' # Web browser
 cask 'ghostty' # Terminal emulator
 cask 'insomnia' # REST client
+cask 'raycast' # Extendable launcher app
 cask 'readdle-spark' # Email client
 cask 'spotify' # Music streaming service
 cask 'tableplus' # GUI for databases
@@ -58,5 +62,5 @@ cask 'zoom' # Video conferencing software
 
 # Install mas apps
 # mas 'Keycastr',    id: 1058125028 # Keystroke visualizer
-mas 'Lungo',       id: 1263070803 # Prevents your Mac from going to sleep
-mas 'Magnet',      id: 441258766 # Window manager
+# mas 'Lungo',       id: 1263070803 # Prevents your Mac from going to sleep
+# mas 'Magnet',      id: 441258766 # Window manager

--- a/claude/claude_desktop_config.json.template
+++ b/claude/claude_desktop_config.json.template
@@ -6,18 +6,13 @@
         "-y",
         "@modelcontextprotocol/server-sequential-thinking"
       ]
-    },
-    "serena": {
-      "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/oraios/serena",
-        "serena",
-        "start-mcp-server"
-      ]
     }
   },
   "preferences": {
-    "chromeExtensionEnabled": true
+    "chromeExtensionEnabled": true,
+    "coworkScheduledTasksEnabled": true,
+    "sidebarMode": "chat",
+    "coworkWebSearchEnabled": true,
+    "ccdScheduledTasksEnabled": true
   }
 }

--- a/macos/aliases.zsh
+++ b/macos/aliases.zsh
@@ -6,4 +6,4 @@ alias ....="cd ../../.."
 alias .....="cd ../../../.."
 
 # Claude Code Orchestration
-alias cldyo='export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 && claude -p --dangerously-skip-permissions --model opus'
+alias cldyo='export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 && claude --dangerously-skip-permissions --model opus --teammate-mode tmux'

--- a/macos/aliases.zsh
+++ b/macos/aliases.zsh
@@ -4,3 +4,6 @@ alias ..="cd .."
 alias ...="cd ../.."
 alias ....="cd ../../.."
 alias .....="cd ../../../.."
+
+# Claude Code Orchestration
+alias cldyo='export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 && claude -p --dangerously-skip-permissions --model opus'

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -127,3 +127,5 @@ eval "$(starship init zsh)"
 
 # GPG signature
 export GPG_TTY=$(tty)
+
+export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
This pull request introduces several improvements and additions to the development environment setup, focusing on enhanced terminal productivity, Python environment management, and Claude Code orchestration. The most important changes are grouped below by theme.

**Terminal and Productivity Tools:**

* Added `tmux` and `pyenv` to the `Brewfile` for terminal multiplexing and Python virtual environment management.
* Added `cmux` (Ghostty-based terminal with vertical tabs) and `raycast` (extendable launcher app) to the cask section of the `Brewfile`. [[1]](diffhunk://#diff-1b33d9c13a9a1b0c5d5bc83697ba7b4d36e6cf45f78184c3a28527ffc4418e2dR46) [[2]](diffhunk://#diff-1b33d9c13a9a1b0c5d5bc83697ba7b4d36e6cf45f78184c3a28527ffc4418e2dR55)

**Claude Code Orchestration:**

* Introduced a new alias `cldyo` in `macos/aliases.zsh` for launching Claude in teammate mode with `tmux` and experimental agent teams.
* Updated `claude_desktop_config.json.template` preferences to enable sidebar chat mode, cowork scheduled tasks, web search, and CCD scheduled tasks. Also removed the `serena` command configuration.

**Path and Environment Setup:**

* Added `$HOME/.local/bin` to the `PATH` in `zsh/zshrc.symlink` for improved accessibility to locally installed binaries.

**Other Adjustments:**

* Commented out `mas` installs for `Lungo` and `Magnet` in the `Brewfile`, indicating these Mac App Store apps are no longer automatically installed.