### PR TITLE
feat: add tmux configuration and installation scripts

### DIFF
--- a/.changeset/fiery-mammals-fall.md
+++ b/.changeset/fiery-mammals-fall.md
@@ -1,0 +1,5 @@
+---
+'tk-dotfiles': minor
+---
+
+add tmux configuration and installation scripts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ The main orchestration script (`bin/dot`) handles three modes:
 ### Symlink Management
 
 Symlinks are created automatically from `*.symlink` files:
+
 - Files are linked from topics into `$HOME`
 - The script handles conflicts (skip, overwrite, backup)
 - Only changed symlinks are updated during `dot update`
@@ -112,6 +113,7 @@ Symlinks are created automatically from `*.symlink` files:
 ### Node.js Management
 
 Uses FNM (Fast Node Manager) instead of nvm:
+
 - Node binaries are symlinked to `/usr/local/bin` for system-wide access
 - This enables GUI apps and MCP servers to use Node
 - Homebrew's Node is automatically removed if detected
@@ -122,6 +124,7 @@ Uses FNM (Fast Node Manager) instead of nvm:
 ### Brewfile
 
 The Brewfile manages three types of installations:
+
 1. Brew Taps - service level tasks
 2. Brew formulas - CLI tools (git, gh, fnm, starship, etc.)
 3. Casks - GUI applications (Chrome, Discord, Warp, Zoom, etc.)
@@ -131,6 +134,7 @@ The Brewfile manages three types of installations:
 ### FNM Node Management
 
 FNM is preferred over Homebrew's Node:
+
 - Node.js LTS is installed via FNM
 - Symlinks are created for global access (node, npm, npx, corepack)
 - If any formula installs node as a dependency, it's removed by `fnm/install.sh` and `bin/dot`
@@ -146,22 +150,26 @@ FNM is preferred over Homebrew's Node:
 The `claude/` topic configures Model Context Protocol (MCP) servers for Claude Desktop and Claude Code:
 
 **For Claude Desktop:**
+
 - Symlinks `claude_desktop_config.json.template` to `~/Library/Application Support/Claude/`
 - Configured servers: `sequential-thinking` (npx), `serena` (uvx)
 - Preserves existing user configurations if present
 - Requires fully quitting Claude Desktop (File → Exit) and restarting after changes
 
 **For Claude Code:**
+
 - Automatically adds MCP servers via `claude mcp add` command
 - Same servers as Claude Desktop: `sequential-thinking`, `serena`
 - Use `/mcp` command in Claude Code to authenticate servers
 
 **Dependencies:**
+
 - Node.js via FNM (for `npx` command)
 - `uv` via Homebrew (for `uvx` command)
 - Gracefully skips setup if Claude Desktop/Code is not installed
 
 **Adding more servers:**
+
 - Edit `claude/claude_desktop_config.json.template`
 - Run `./claude/install.sh` or `dot install`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ The main orchestration script (`bin/dot`) handles three modes:
 2. **`install`**: Full installation
    - Updates symlinks
    - Installs all Brewfile packages
-   - Runs topic installers (macos, fnm, zsh, claude)
+   - Runs topic installers (macos, fnm, zsh, tmux)
    - Configures Claude Desktop/Code MCP servers (if installed)
    - Applies macOS system defaults
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Full installation - useful after major changes or pulling updates:
 
 - 🔗 Updates all symlinks
 - 📦 Installs all Brewfile packages
-- ⚙️ Runs all topic installers (macOS, FNM, Zsh, tmux, Claude)
+- ⚙️ Runs all topic installers (macOS, FNM, Zsh, tmux)
 - 🤖 Configures Claude Desktop/Code MCP servers
 - 🍏 Applies macOS system defaults
 - 🔐 Only prompts for sudo when actually needed

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ I use (Typescript/JavaScript, Node, Go, git, system libraries, and so on), so th
 
 Below is the general layout of my setup. Please review this _**before**_ running the install scripts.
 
-- **bin/**: Anything in `bin/` will be added to your `$PATH` and available everywhere.
+- **bin/**: Anything in `bin/` will be added to your `$PATH` and available everywhere. Includes `dot` (dotfiles manager), `e` (editor launcher), and `claude-agents` (multi-pane tmux launcher for Claude Code agents).
 - **Brewfile**: Manages three types of applications:
   1. Brew Tap - service level tasks
   2. Brew formulas - command-line tools and packages
@@ -31,6 +31,10 @@ Below is the general layout of my setup. Please review this _**before**_ running
   - **Claude Code**: Adds MCP servers via CLI (`sequential-thinking`, `serena`)
   - Gracefully skips setup if Claude Desktop/Code is not installed
   - Preserves existing user configurations
+- **tmux/**: Terminal multiplexer configuration for multi-pane workflows (e.g., running Claude Code agents side by side). Includes:
+  - **tmux.conf.symlink**: Full tmux config with Ctrl+a prefix, vim-style navigation, mouse support, and a Tokyo Night-inspired status bar
+  - **install.sh**: Installs TPM (Tmux Plugin Manager) and plugins (`tmux-sensible`, `tmux-resurrect`, `tmux-continuum`, `tmux-yank`)
+  - **aliases.zsh**: Tmux shortcuts (`ta`, `ts`, `tl`, etc.) and Claude Code orchestration alias (`cldyo`)
 - **topic/\*.zsh**: Any files ending in `.zsh` get loaded into your
   environment.
 - **topic/path.zsh**: Any file named `path.zsh` is loaded first and is
@@ -96,7 +100,7 @@ If you choose to continue, the installation (`dot install`) will:
 
 1. 📦 Install all packages from the Brewfile (brew, cask, and mas apps)
 2. 🔧 Set up FNM and Node.js LTS
-3. ⚙️ Run all topic-specific installers (macos, fnm, zsh, claude)
+3. ⚙️ Run all topic-specific installers (macos, fnm, zsh, tmux, claude)
 4. 🍏 Apply macOS system defaults
 
 ### Password Prompts
@@ -114,6 +118,7 @@ On subsequent runs, if everything is already configured, you may not be prompted
 - **Cask applications**: GUI apps like Chrome, Discord, Warp, Zoom, Claude
 - **Node.js**: Latest LTS version via FNM
 - **Oh My Zsh**: If not already installed
+- **tmux + TPM**: Tmux Plugin Manager and plugins (resurrect, continuum, yank)
 - **Claude MCP servers**: Model Context Protocol servers for Claude Desktop and Claude Code
   - **sequential-thinking**: Enhanced reasoning capabilities (via npx)
   - **serena**: Advanced code analysis and understanding (via uvx)
@@ -161,7 +166,7 @@ Full installation - useful after major changes or pulling updates:
 
 - 🔗 Updates all symlinks
 - 📦 Installs all Brewfile packages
-- ⚙️ Runs all topic installers (macOS, FNM, Zsh, Claude)
+- ⚙️ Runs all topic installers (macOS, FNM, Zsh, tmux, Claude)
 - 🤖 Configures Claude Desktop/Code MCP servers
 - 🍏 Applies macOS system defaults
 - 🔐 Only prompts for sudo when actually needed
@@ -245,6 +250,29 @@ FNM (Fast Node Manager) is used instead of nvm for better performance. Node.js b
 - GUI applications that need Node.js
 - System services and LaunchAgents
 
+### tmux and Claude Code Agents
+
+tmux is configured with TPM (Tmux Plugin Manager) for plugin management. The `claude-agents` script creates multi-pane tmux sessions for running Claude Code agents side by side:
+
+```sh
+claude-agents              # 2 panes (default)
+claude-agents 3            # 3 panes
+claude-agents 4 myproject  # 4 panes, session named "myproject"
+```
+
+Key tmux keybindings (prefix is `Ctrl+a`):
+
+| Keybinding       | Action                     |
+| ---------------- | -------------------------- |
+| `Ctrl+a \|`      | Split pane vertically      |
+| `Ctrl+a -`       | Split pane horizontally    |
+| `Ctrl+a h/j/k/l` | Navigate panes (vim-style) |
+| `Ctrl+a r`       | Reload tmux config         |
+
+**Installing TPM plugins manually**: If plugins aren't installed, press `Ctrl+a I` (capital I) inside tmux to trigger TPM plugin installation.
+
+**Session persistence**: `tmux-resurrect` and `tmux-continuum` auto-save your session layout every 15 minutes. After a reboot, run `tmux` and your pane layout will be restored automatically.
+
 ### Claude Desktop and MCP Servers
 
 Claude Desktop and Claude Code can be extended with MCP (Model Context Protocol) servers. The dotfiles automatically configure two powerful servers:
@@ -253,17 +281,20 @@ Claude Desktop and Claude Code can be extended with MCP (Model Context Protocol)
 - **serena**: Offers advanced code analysis and symbol-level understanding
 
 **Setup Requirements**:
+
 - Claude Desktop must be installed via Brewfile (`cask 'claude'`)
 - OR Claude Code must be installed (`brew install --cask claude-code`)
 - Node.js via FNM (for `npx` command)
 - `uv` via Homebrew (for `uvx` command)
 
 **Post-Installation**:
+
 - **Claude Desktop**: After running `dot install`, fully quit Claude (File → Exit, not just close window) and restart
 - **Claude Code**: Run `/mcp` command to authenticate MCP servers
 - Look for the hammer icon in Claude Desktop interface to verify MCP tools are loaded
 
 **Adding More MCP Servers**:
+
 - **Claude Desktop**: Edit `claude/claude_desktop_config.json.template` and run `./claude/install.sh`
 - **Claude Code**: Use `claude mcp add` command (see `claude mcp --help`)
 

--- a/bin/claude-agents
+++ b/bin/claude-agents
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -e
+
+# claude-agents - Launch a tmux session with multiple panes for Claude Code agents
+#
+# Usage:
+#   claude-agents              # 2 panes (default)
+#   claude-agents 3            # 3 panes
+#   claude-agents 4 myproject  # 4 panes, session named "myproject"
+
+PANE_COUNT="${1:-2}"
+SESSION_NAME="${2:-claude-agents}"
+
+# Validate pane count
+if ! [[ "$PANE_COUNT" =~ ^[2-6]$ ]]; then
+	echo "Usage: claude-agents [panes:2-6] [session-name]"
+	exit 1
+fi
+
+# Check prerequisites
+if ! command -v tmux &>/dev/null; then
+	echo "Error: tmux is not installed. Run 'dot install' first."
+	exit 1
+fi
+
+# Reattach to existing session
+if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+	echo "Session '$SESSION_NAME' already exists. Attaching..."
+	exec tmux attach-session -t "$SESSION_NAME"
+fi
+
+# Create new session with first pane
+tmux new-session -d -s "$SESSION_NAME"
+
+# Create additional panes
+for ((i = 2; i <= PANE_COUNT; i++)); do
+	tmux split-window -t "$SESSION_NAME" -h
+	tmux select-layout -t "$SESSION_NAME" tiled
+done
+
+# Final layout adjustment
+tmux select-layout -t "$SESSION_NAME" tiled
+tmux select-pane -t "$SESSION_NAME:1.1"
+
+# Attach
+exec tmux attach-session -t "$SESSION_NAME"

--- a/bin/dot
+++ b/bin/dot
@@ -354,6 +354,11 @@ cmd_install() {
 		source "$DOTFILES/zsh/install.sh"
 	fi
 
+	# Run tmux installer
+	if [ -f "$DOTFILES/tmux/install.sh" ]; then
+		source "$DOTFILES/tmux/install.sh"
+	fi
+
 	# Set macOS defaults
 	if [ -f "$DOTFILES/macos/set-defaults.sh" ]; then
 		echo ""

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,3 @@
 export default {
   extends: ['@commitlint/config-conventional'],
-};
+}

--- a/docs/plans/2025-11-17-claude-mcp-servers-design.md
+++ b/docs/plans/2025-11-17-claude-mcp-servers-design.md
@@ -38,19 +38,11 @@ The template will be a complete, valid JSON file:
   "mcpServers": {
     "serena": {
       "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/oraios/serena",
-        "serena",
-        "start-mcp-server"
-      ]
+      "args": ["--from", "git+https://github.com/oraios/serena", "serena", "start-mcp-server"]
     },
     "sequential-thinking": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-sequential-thinking"
-      ]
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
     }
   }
 }
@@ -83,16 +75,19 @@ The `claude/install.sh` script will:
 ## Integration with Existing System
 
 ### Dependencies (already in Brewfile)
+
 - `brew 'uv'` - for Serena's uvx command
 - `cask 'claude'` - Claude Desktop app
 - Node.js via FNM - for npx command
 
 ### Dotfiles Integration
+
 - `dot install` automatically runs `claude/install.sh`
 - `dot update` doesn't need special handling
 - No changes needed to existing scripts
 
 ### Adding More MCP Servers
+
 1. Edit `claude/claude_desktop_config.json.template`
 2. Run `./claude/install.sh` or `dot install`
 3. Fully quit Claude Desktop (File → Exit)
@@ -125,6 +120,7 @@ User must fully quit Claude Desktop (File → Exit, not just close window) and r
 ## Testing
 
 To verify the setup:
+
 1. Run `dot install`
 2. Check for config symlink: `ls -la ~/Library/Application\ Support/Claude/`
 3. Verify symlink target points to dotfiles template

--- a/macos/aliases.zsh
+++ b/macos/aliases.zsh
@@ -4,6 +4,3 @@ alias ..="cd .."
 alias ...="cd ../.."
 alias ....="cd ../../.."
 alias .....="cd ../../../.."
-
-# Claude Code Orchestration
-alias cldyo='export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 && claude --dangerously-skip-permissions --model opus --teammate-mode tmux'

--- a/tmux/aliases.zsh
+++ b/tmux/aliases.zsh
@@ -1,0 +1,10 @@
+# Tmux aliases
+alias ta='tmux attach -t'
+alias tad='tmux attach -d -t'
+alias ts='tmux new-session -s'
+alias tl='tmux list-sessions'
+alias tksv='tmux kill-server'
+alias tkss='tmux kill-session -t'
+
+# Claude Code Orchestration
+alias cldyo='export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 && claude --dangerously-skip-permissions --model opus --teammate-mode tmux'

--- a/tmux/aliases.zsh
+++ b/tmux/aliases.zsh
@@ -6,5 +6,9 @@ alias tl='tmux list-sessions'
 alias tksv='tmux kill-server'
 alias tkss='tmux kill-session -t'
 
+# WARNING: The alias below uses --dangerously-skip-permissions, which allows
+# Claude Code to execute tools (shell commands, file writes, etc.) without
+# prompting for user confirmation. Only use this in trusted, sandboxed
+# environments. Do not source this file on shared or production machines.
 # Claude Code Orchestration
 alias cldyo='export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 && claude --dangerously-skip-permissions --model opus --teammate-mode tmux'

--- a/tmux/install.sh
+++ b/tmux/install.sh
@@ -17,6 +17,9 @@ fi
 # Install tmux plugins non-interactively
 if command -v tmux &>/dev/null && [ -d "$TPM_DIR" ]; then
 	echo "  Installing tmux plugins..."
-	"$TPM_DIR/bin/install_plugins" 2>/dev/null || true
-	echo -e "  ${GREEN}✓ Tmux plugins installed${NC}"
+	if "$TPM_DIR/bin/install_plugins" 2>&1; then
+		echo -e "  ${GREEN}✓ Tmux plugins installed${NC}"
+	else
+		echo -e "  ${YELLOW}⚠ Tmux plugin installation failed (exit $?)${NC}" >&2
+	fi
 fi

--- a/tmux/install.sh
+++ b/tmux/install.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Install TPM (Tmux Plugin Manager)
+
+echo ""
+echo "Setting up tmux..."
+
+TPM_DIR="$HOME/.tmux/plugins/tpm"
+
+if [ ! -d "$TPM_DIR" ]; then
+	echo "  Installing TPM..."
+	git clone https://github.com/tmux-plugins/tpm "$TPM_DIR"
+	echo -e "  ${GREEN}✓ TPM installed${NC}"
+else
+	echo -e "  ${GREEN}✓ TPM already installed${NC}"
+fi
+
+# Install tmux plugins non-interactively
+if command -v tmux &>/dev/null && [ -d "$TPM_DIR" ]; then
+	echo "  Installing tmux plugins..."
+	"$TPM_DIR/bin/install_plugins" 2>/dev/null || true
+	echo -e "  ${GREEN}✓ Tmux plugins installed${NC}"
+fi

--- a/tmux/tmux.conf.symlink
+++ b/tmux/tmux.conf.symlink
@@ -1,0 +1,99 @@
+# ──────────────────────────────────────────────
+# Terminal & Colors
+# ──────────────────────────────────────────────
+set -g default-terminal "screen-256color"
+set-option -sa terminal-overrides ",xterm*:Tc"
+
+# ──────────────────────────────────────────────
+# General Settings
+# ──────────────────────────────────────────────
+# Change prefix from Ctrl+b to Ctrl+a
+unbind C-b
+set -g prefix C-a
+bind C-a send-prefix
+
+# Enable mouse support
+set -g mouse on
+
+# Start windows and panes at 1, not 0
+set -g base-index 1
+setw -g pane-base-index 1
+
+# Renumber windows when one is closed
+set -g renumber-windows on
+
+# Increase scrollback buffer
+set -g history-limit 50000
+
+# Reduce escape time for faster key response
+set -sg escape-time 0
+
+# Enable focus events
+set -g focus-events on
+
+# ──────────────────────────────────────────────
+# Key Bindings
+# ──────────────────────────────────────────────
+# Vi mode for copy
+setw -g mode-keys vi
+
+# Split panes with | and - (in current path)
+bind | split-window -h -c "#{pane_current_path}"
+bind - split-window -v -c "#{pane_current_path}"
+unbind '"'
+unbind %
+
+# New window in current path
+bind c new-window -c "#{pane_current_path}"
+
+# Vim-style pane navigation
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
+
+# Resize panes with Shift+arrow
+bind -r H resize-pane -L 5
+bind -r J resize-pane -D 5
+bind -r K resize-pane -U 5
+bind -r L resize-pane -R 5
+
+# Quick reload config
+bind r source-file ~/.tmux.conf \; display "Config reloaded!"
+
+# ──────────────────────────────────────────────
+# Status Bar
+# ──────────────────────────────────────────────
+set -g status-position bottom
+set -g status-style "bg=#1a1b26,fg=#a9b1d6"
+set -g status-left-length 40
+set -g status-right-length 60
+set -g status-left "#[fg=#7aa2f7,bold] #S #[fg=#545c7e]│ "
+set -g status-right "#[fg=#545c7e]│ #[fg=#a9b1d6]%Y-%m-%d #[fg=#545c7e]│ #[fg=#7aa2f7]%H:%M "
+
+# Window status
+setw -g window-status-format "#[fg=#545c7e] #I:#W "
+setw -g window-status-current-format "#[fg=#7aa2f7,bold] #I:#W "
+
+# Pane borders
+set -g pane-border-style "fg=#545c7e"
+set -g pane-active-border-style "fg=#7aa2f7"
+
+# Message style
+set -g message-style "bg=#1a1b26,fg=#7aa2f7"
+
+# ──────────────────────────────────────────────
+# Plugins (via TPM)
+# ──────────────────────────────────────────────
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-sensible'
+set -g @plugin 'tmux-plugins/tmux-resurrect'
+set -g @plugin 'tmux-plugins/tmux-continuum'
+set -g @plugin 'tmux-plugins/tmux-yank'
+
+# Plugin settings
+set -g @continuum-restore 'on'
+set -g @resurrect-capture-pane-contents 'on'
+
+# Initialize TPM (keep at bottom)
+run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
This pull request introduces a new, comprehensive tmux configuration to the dotfiles setup, including installation scripts, plugin management, and improved documentation. It also reorganizes aliases, updates install flows, and enhances documentation for both tmux and Claude MCP server integration. The changes improve multi-pane workflows, session persistence, and user onboarding.

**tmux Integration and Configuration:**

- Added a new `tmux/` directory with a full-featured `tmux.conf.symlink` configuration, including a Ctrl+a prefix, vim-style navigation, mouse support, a Tokyo Night-inspired status bar, and plugin integration via TPM (Tmux Plugin Manager).
- Added `tmux/install.sh` to automate TPM and plugin installation, ensuring plugins like `tmux-resurrect`, `tmux-continuum`, and `tmux-yank` are set up automatically.
- Introduced `tmux/aliases.zsh` with tmux session management shortcuts and moved the `cldyo` Claude Code orchestration alias here from `macos/aliases.zsh`. [[1]](diffhunk://#diff-6f493a4f4378aee79578caa4e61998238d1a937a606c70b343de18d75a222128R1-R10) [[2]](diffhunk://#diff-33a9c7e6d02ae3dc2cedb78e588ddce1b2694d925d852e8966f3aa3ff77c4cdbL7-L9)

**Documentation Updates:**

- Expanded `README.md` and `CLAUDE.md` to document tmux workflows, keybindings, plugin installation, and how the new tmux setup enables multi-pane sessions for Claude Code agents. Also clarified install steps and updated lists of topic installers. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R34-R37) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L99-R103) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R121) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L164-R169) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R253-R275) [[6]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R108-R116)
- Updated documentation for Claude MCP server setup, requirements, and integration with the new install flow. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R284-R297) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R153-R172) [[3]](diffhunk://#diff-b9cae0f71118e9ca53ef548471d143bbbd3e90155c2484b543653d7ef9acd1e9L41-R45) [[4]](diffhunk://#diff-b9cae0f71118e9ca53ef548471d143bbbd3e90155c2484b543653d7ef9acd1e9R78-R90) [[5]](diffhunk://#diff-b9cae0f71118e9ca53ef548471d143bbbd3e90155c2484b543653d7ef9acd1e9R123)

**Install and Orchestration Flow:**

- Modified install scripts and documentation to include tmux as a first-class topic, ensuring it is set up during `dot install` and `dot update`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L99-R103) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L164-R169) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R127) [[4]](diffhunk://#diff-413da8a0cc069e34f2fbace82c00e645a906358bf9ca9ab9d9e6781fd7aad802R1-R5)

**Miscellaneous:**

- Minor fix to `commitlint.config.js` for syntax consistency.

**References:** [[1]](diffhunk://#diff-9ea42bdcdde0e37b46f458d82e77c1f85908afb7f1d18f8d6db9a517675ee3d0R1-R99) [[2]](diffhunk://#diff-aff02d76d8096a00b681ccc0217786862310f0a6237f50fb4412edb2a31e6f79R1-R22) [[3]](diffhunk://#diff-6f493a4f4378aee79578caa4e61998238d1a937a606c70b343de18d75a222128R1-R10) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R34-R37) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L99-R103) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R121) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L164-R169) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R253-R275) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R284-R297) [[10]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R108-R116) [[11]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R127) [[12]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R153-R172) [[13]](diffhunk://#diff-b9cae0f71118e9ca53ef548471d143bbbd3e90155c2484b543653d7ef9acd1e9L41-R45) [[14]](diffhunk://#diff-b9cae0f71118e9ca53ef548471d143bbbd3e90155c2484b543653d7ef9acd1e9R78-R90) [[15]](diffhunk://#diff-b9cae0f71118e9ca53ef548471d143bbbd3e90155c2484b543653d7ef9acd1e9R123) [[16]](diffhunk://#diff-33a9c7e6d02ae3dc2cedb78e588ddce1b2694d925d852e8966f3aa3ff77c4cdbL7-L9) [[17]](diffhunk://#diff-413da8a0cc069e34f2fbace82c00e645a906358bf9ca9ab9d9e6781fd7aad802R1-R5) [[18]](diffhunk://#diff-2b1ae4316086c0ebb213227790133a792300e1cef03b0afc067b23d3399ea5caL3-R3)