### PR TITLE
feat: add new brew recipes

### DIFF
--- a/.changeset/spotty-bats-cheat.md
+++ b/.changeset/spotty-bats-cheat.md
@@ -1,0 +1,5 @@
+---
+'tk-dotfiles': minor
+---
+
+Added new brew recipes for bun and just

--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,7 @@
 cask_args appdir: '/Applications'
 
 tap 'mongodb/brew'
+tap 'oven-sh/bun'
 
 # gnu stuff
 brew 'bash' # Bash 5.x (macOS ships with 3.2)
@@ -20,10 +21,12 @@ brew 'fnm' # Node.js version manager and corepack installer
 brew 'gh' # GitHub official CLI (replaces deprecated hub)
 brew 'imagemagick' # Image manipulation library
 brew 'jq' # Lightweight and flexible command-line JSON processor
+brew 'just' # Task runner
 brew 'libgit2' # C library of Git core methods that is re-entrant and linkable
 brew 'mas' # CLI for installing app from Mac App Store
 brew 'mongodb-community', restart_service: false # NoSQL database (manual start: brew services start mongodb-community)
 brew 'openssl' # Cryptography and SSL/TLS Toolkit
+brew 'pi-coding-agent' # Customize agent harness
 brew 'postgresql', restart_service: false # SQL database (manual start: brew services start postgresql)
 brew 'pyenv' # Python virtual env
 brew 'readline' # Library for command-line editing

--- a/claude/claude_desktop_config.json.template
+++ b/claude/claude_desktop_config.json.template
@@ -11,8 +11,8 @@
   "preferences": {
     "chromeExtensionEnabled": true,
     "coworkScheduledTasksEnabled": true,
+    "ccdScheduledTasksEnabled": true,
     "sidebarMode": "chat",
-    "coworkWebSearchEnabled": true,
-    "ccdScheduledTasksEnabled": true
+    "coworkWebSearchEnabled": true
   }
 }


### PR DESCRIPTION
This pull request updates development environment configuration files to add new tools and adjust application preferences. The most significant changes are the addition of new Homebrew taps and packages, and a minor update to the desktop application's configuration template.

**Homebrew configuration updates:**

* Added the `oven-sh/bun` tap to enable installation of Bun-related packages.
* Added `just` (a task runner) and `pi-coding-agent` (custom agent harness) to the list of Homebrew packages to be installed.

**Desktop application configuration:**

* In `claude_desktop_config.json.template`, moved the `ccdScheduledTasksEnabled` preference above `sidebarMode` for improved organization. No functional change was made.