### PR TITLE
feat(iterm2): auto-install it2 CLI via uv tool

### DIFF
--- a/.changeset/iterm2-it2-installer.md
+++ b/.changeset/iterm2-it2-installer.md
@@ -1,0 +1,5 @@
+---
+'tk-dotfiles': minor
+---
+
+Add iterm2 topic installer that auto-installs the it2 CLI via uv tool when iTerm2 is present, and upgrades it on dot update. Introduces a DOT_MODE env signal so topic installers can branch on install vs update lifecycle.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,22 @@ FNM is preferred over Homebrew's Node:
 - `macos/set-defaults.sh`: Applies system preferences (requires sudo)
 - Both scripts are run during `dot install`
 
+### iTerm2 CLI Tooling
+
+The `iterm2/` topic installs uv-managed CLI tools that complement iTerm2 (e.g., `it2`):
+
+- Gated on iTerm2 being installed at `/Applications/iTerm.app` (skips silently otherwise)
+- Gated on `uv` being available (Brewfile guarantees this)
+- Tools listed in the `UV_TOOLS=("it2")` array inside `iterm2/install.sh` — add entries to extend
+- Runs in both `dot install` and `dot update`:
+  - `dot install` (DOT_MODE=install): installs missing tools
+  - `dot update` (DOT_MODE=update): installs missing tools and upgrades existing ones
+- Failures on a single tool emit a warning and continue — never abort the broader `dot` run
+
+**Adding more uv tools:**
+
+- Edit `UV_TOOLS=()` in `iterm2/install.sh` and re-run `dot install` or `dot update`
+
 ### Claude MCP Servers
 
 The `claude/` topic configures Model Context Protocol (MCP) servers for Claude Desktop and Claude Code:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ FNM is preferred over Homebrew's Node:
 
 The `iterm2/` topic installs uv-managed CLI tools that complement iTerm2 (e.g., `it2`):
 
-- Gated on iTerm2 being installed at `/Applications/iTerm.app` (skips silently otherwise)
+- Gated on iTerm2 being installed at `/Applications/iTerm.app` (prints a skip notice and exits 0 otherwise)
 - Gated on `uv` being available (Brewfile guarantees this)
 - Tools listed in the `UV_TOOLS=("it2")` array inside `iterm2/install.sh` — add entries to extend
 - Runs in both `dot install` and `dot update`:

--- a/bin/dot
+++ b/bin/dot
@@ -349,6 +349,11 @@ cmd_install() {
 		fi
 	fi
 
+	# Run iTerm2 installer
+	if [ -f "$DOTFILES/iterm2/install.sh" ]; then
+		DOT_MODE=install source "$DOTFILES/iterm2/install.sh"
+	fi
+
 	# Run zsh installer
 	if [ -f "$DOTFILES/zsh/install.sh" ]; then
 		source "$DOTFILES/zsh/install.sh"

--- a/bin/dot
+++ b/bin/dot
@@ -449,6 +449,11 @@ cmd_update() {
 	brew cleanup
 	echo -e "  ${GREEN}✓ Cleanup complete${NC}"
 
+	# Run iTerm2 installer in update mode
+	if [ -f "$DOTFILES/iterm2/install.sh" ]; then
+		DOT_MODE=update source "$DOTFILES/iterm2/install.sh"
+	fi
+
 	# Update npm global packages (if FNM/Node is available)
 	if command -v npm &> /dev/null; then
 		NPM_GLOBALS=(

--- a/docs/superpowers/plans/2026-04-27-iterm2-it2-installer.md
+++ b/docs/superpowers/plans/2026-04-27-iterm2-it2-installer.md
@@ -14,12 +14,12 @@
 
 ## File Structure
 
-| Path | Action | Responsibility |
-|---|---|---|
-| `iterm2/install.sh` | Create | Topic installer — guards, `UV_TOOLS` array, install + upgrade loop |
-| `bin/dot` | Modify (2 sites) | Source `iterm2/install.sh` from `cmd_install` and `cmd_update`, exporting `DOT_MODE` |
-| `CLAUDE.md` | Modify | Document the `iterm2/` topic and `UV_TOOLS` extension pattern |
-| `.changeset/iterm2-it2-installer.md` | Create | Changeset entry (project convention) |
+| Path                                 | Action           | Responsibility                                                                       |
+| ------------------------------------ | ---------------- | ------------------------------------------------------------------------------------ |
+| `iterm2/install.sh`                  | Create           | Topic installer — guards, `UV_TOOLS` array, install + upgrade loop                   |
+| `bin/dot`                            | Modify (2 sites) | Source `iterm2/install.sh` from `cmd_install` and `cmd_update`, exporting `DOT_MODE` |
+| `CLAUDE.md`                          | Modify           | Document the `iterm2/` topic and `UV_TOOLS` extension pattern                        |
+| `.changeset/iterm2-it2-installer.md` | Create           | Changeset entry (project convention)                                                 |
 
 No test framework exists in this repo; verification is manual smoke testing using concrete commands with expected output, per the project's existing convention.
 
@@ -28,6 +28,7 @@ No test framework exists in this repo; verification is manual smoke testing usin
 ## Task 1: Create `iterm2/install.sh` with guards and core loop
 
 **Files:**
+
 - Create: `iterm2/install.sh`
 
 - [ ] **Step 1.1: Create `iterm2/install.sh` with full content**
@@ -89,6 +90,7 @@ echo "  ✓ iTerm2 CLI tooling setup complete"
 - [ ] **Step 1.2: Make it executable**
 
 Run:
+
 ```bash
 chmod +x /Users/tk/.dotfiles/iterm2/install.sh
 ```
@@ -98,6 +100,7 @@ Expected: no output.
 - [ ] **Step 1.3: Syntax-check the script**
 
 Run:
+
 ```bash
 bash -n /Users/tk/.dotfiles/iterm2/install.sh
 ```
@@ -107,11 +110,13 @@ Expected: no output, exit 0.
 - [ ] **Step 1.4: Verify the "already installed" path (DOT_MODE unset → install semantics)**
 
 Run:
+
 ```bash
 bash /Users/tk/.dotfiles/iterm2/install.sh
 ```
 
 Expected output includes:
+
 ```
 🖥️  Setting up iTerm2 CLI tooling...
   ✓ it2 already installed
@@ -123,11 +128,13 @@ Expected output includes:
 - [ ] **Step 1.5: Verify the upgrade path (DOT_MODE=update)**
 
 Run:
+
 ```bash
 DOT_MODE=update bash /Users/tk/.dotfiles/iterm2/install.sh
 ```
 
 Expected output includes:
+
 ```
 🖥️  Setting up iTerm2 CLI tooling...
   🔄 Upgrading it2...
@@ -141,6 +148,7 @@ Expected output includes:
 - [ ] **Step 1.6: Verify the iTerm2-missing skip path**
 
 Run:
+
 ```bash
 # Simulate missing iTerm2 by overriding the path test via a wrapper script
 DOT_MODE=install bash -c '
@@ -171,11 +179,13 @@ Expected: commit succeeds.
 ## Task 2: Wire `iterm2/install.sh` into `cmd_install`
 
 **Files:**
+
 - Modify: `bin/dot` (insert after the FNM block, before the zsh installer block)
 
 - [ ] **Step 2.1: Locate the insertion site**
 
 Run:
+
 ```bash
 grep -n "Run zsh installer" /Users/tk/.dotfiles/bin/dot
 ```
@@ -216,6 +226,7 @@ Replace with:
 - [ ] **Step 2.3: Syntax-check `bin/dot`**
 
 Run:
+
 ```bash
 bash -n /Users/tk/.dotfiles/bin/dot
 ```
@@ -225,11 +236,13 @@ Expected: no output, exit 0.
 - [ ] **Step 2.4: Verify the install branch executes correctly via dry-run trace**
 
 Run:
+
 ```bash
 grep -B 1 -A 3 "iterm2/install.sh" /Users/tk/.dotfiles/bin/dot
 ```
 
 Expected output (one match, in `cmd_install`):
+
 ```
 	# Run iTerm2 installer
 	if [ -f "$DOTFILES/iterm2/install.sh" ]; then
@@ -255,11 +268,13 @@ Expected: commit succeeds.
 ## Task 3: Wire `iterm2/install.sh` into `cmd_update`
 
 **Files:**
+
 - Modify: `bin/dot` (insert after the brew bundle check + node cleanup blocks, before npm globals update block)
 
 - [ ] **Step 3.1: Locate the insertion site**
 
 Run:
+
 ```bash
 grep -n "Cleanup complete\|Updating npm global\|Update npm global packages" /Users/tk/.dotfiles/bin/dot
 ```
@@ -300,6 +315,7 @@ Replace with:
 - [ ] **Step 3.3: Syntax-check `bin/dot`**
 
 Run:
+
 ```bash
 bash -n /Users/tk/.dotfiles/bin/dot
 ```
@@ -309,6 +325,7 @@ Expected: no output, exit 0.
 - [ ] **Step 3.4: Verify both install and update sites are wired**
 
 Run:
+
 ```bash
 grep -c "iterm2/install.sh" /Users/tk/.dotfiles/bin/dot
 ```
@@ -316,11 +333,13 @@ grep -c "iterm2/install.sh" /Users/tk/.dotfiles/bin/dot
 Expected: `2`
 
 Run:
+
 ```bash
 grep "DOT_MODE=" /Users/tk/.dotfiles/bin/dot
 ```
 
 Expected output (two lines):
+
 ```
 		DOT_MODE=install source "$DOTFILES/iterm2/install.sh"
 		DOT_MODE=update source "$DOTFILES/iterm2/install.sh"
@@ -344,11 +363,13 @@ Expected: commit succeeds.
 ## Task 4: Document the new topic in `CLAUDE.md`
 
 **Files:**
+
 - Modify: `CLAUDE.md` (insert new subsection under "Important Notes")
 
 - [ ] **Step 4.1: Find the "Claude MCP Servers" subsection — we'll add the iTerm2 subsection right above it**
 
 Run:
+
 ```bash
 grep -n "^### Claude MCP Servers" /Users/tk/.dotfiles/CLAUDE.md
 ```
@@ -388,11 +409,13 @@ The `iterm2/` topic installs uv-managed CLI tools that complement iTerm2 (e.g., 
 - [ ] **Step 4.3: Verify the doc renders**
 
 Run:
+
 ```bash
 grep -A 2 "^### iTerm2 CLI Tooling" /Users/tk/.dotfiles/CLAUDE.md
 ```
 
 Expected output:
+
 ```
 ### iTerm2 CLI Tooling
 
@@ -413,6 +436,7 @@ Expected: commit succeeds.
 ## Task 5: Add changeset entry
 
 **Files:**
+
 - Create: `.changeset/iterm2-it2-installer.md`
 
 - [ ] **Step 5.1: Create the changeset file**
@@ -430,6 +454,7 @@ Add iterm2 topic installer that auto-installs the it2 CLI via uv tool when iTerm
 - [ ] **Step 5.2: Verify the changeset format**
 
 Run:
+
 ```bash
 cat /Users/tk/.dotfiles/.changeset/iterm2-it2-installer.md
 ```
@@ -439,6 +464,7 @@ Expected: prints exactly the content above.
 - [ ] **Step 5.3: Run pnpm format to align with repo style**
 
 Run:
+
 ```bash
 cd /Users/tk/.dotfiles && pnpm format
 ```
@@ -463,11 +489,13 @@ Expected: commit succeeds.
 - [ ] **Step 6.1: Run `dot update` end-to-end**
 
 Run:
+
 ```bash
 /Users/tk/.dotfiles/bin/dot update
 ```
 
 Expected behavior in output:
+
 - Standard `dot update` flow runs (symlinks, brew, etc.)
 - After `🧹 Cleaning up Homebrew...` block, see:
   ```
@@ -481,6 +509,7 @@ Expected behavior in output:
 - Final "Update complete" banner
 
 Confirm exit code:
+
 ```bash
 echo $?
 ```
@@ -490,6 +519,7 @@ Expected: `0`
 - [ ] **Step 6.2: Verify `it2` still works**
 
 Run:
+
 ```bash
 it2 --version
 ```
@@ -499,6 +529,7 @@ Expected: prints a version line (should match what `uv tool list` shows for `it2
 - [ ] **Step 6.3: Verify idempotency — run `dot update` again**
 
 Run:
+
 ```bash
 /Users/tk/.dotfiles/bin/dot update
 ```

--- a/docs/superpowers/plans/2026-04-27-iterm2-it2-installer.md
+++ b/docs/superpowers/plans/2026-04-27-iterm2-it2-installer.md
@@ -1,0 +1,527 @@
+# iTerm2 `it2` Auto-Installer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Automate `it2` CLI installation and upgrades through `dot install` / `dot update` when iTerm2 is present.
+
+**Architecture:** New `iterm2/install.sh` topic installer with `UV_TOOLS=("it2")` array, gated on iTerm2 presence and `uv` availability. Sourced by `bin/dot` from both `cmd_install` and `cmd_update` with a `$DOT_MODE` env signal that branches on install vs upgrade.
+
+**Tech Stack:** Bash, `uv tool` subcommand, existing dotfiles topic-installer convention.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-iterm2-it2-installer-design.md`
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `iterm2/install.sh` | Create | Topic installer — guards, `UV_TOOLS` array, install + upgrade loop |
+| `bin/dot` | Modify (2 sites) | Source `iterm2/install.sh` from `cmd_install` and `cmd_update`, exporting `DOT_MODE` |
+| `CLAUDE.md` | Modify | Document the `iterm2/` topic and `UV_TOOLS` extension pattern |
+| `.changeset/iterm2-it2-installer.md` | Create | Changeset entry (project convention) |
+
+No test framework exists in this repo; verification is manual smoke testing using concrete commands with expected output, per the project's existing convention.
+
+---
+
+## Task 1: Create `iterm2/install.sh` with guards and core loop
+
+**Files:**
+- Create: `iterm2/install.sh`
+
+- [ ] **Step 1.1: Create `iterm2/install.sh` with full content**
+
+```bash
+#!/bin/bash
+
+# iTerm2 CLI tooling installer
+# Installs uv-managed CLI tools that complement iTerm2 (e.g., it2).
+# Sourced by bin/dot from cmd_install and cmd_update.
+# Reads $DOT_MODE (install|update) to branch upgrade behavior.
+
+echo ""
+echo "🖥️  Setting up iTerm2 CLI tooling..."
+
+# Guard 1: iTerm2 must be installed
+if [ ! -d "/Applications/iTerm.app" ]; then
+  echo "  ⏩ iTerm2 not installed, skipping it2 setup"
+  return 0 2>/dev/null || exit 0
+fi
+
+# Guard 2: uv must be available (Brewfile guarantees it during dot install)
+if ! command -v uv &> /dev/null; then
+  echo "  ⚠️  uv not found — install via Brewfile"
+  return 0 2>/dev/null || exit 0
+fi
+
+# Tools to install via `uv tool install`. Add entries to extend.
+UV_TOOLS=("it2")
+
+# Default mode is install if not set
+DOT_MODE="${DOT_MODE:-install}"
+
+for tool in "${UV_TOOLS[@]}"; do
+  if uv tool list 2>/dev/null | grep -q "^${tool} "; then
+    if [ "$DOT_MODE" = "update" ]; then
+      echo "  🔄 Upgrading $tool..."
+      if uv tool upgrade "$tool" 2>&1 | sed 's/^/    /'; then
+        echo "  ✓ $tool upgrade complete"
+      else
+        echo "  ⚠️  Failed to upgrade $tool (continuing)"
+      fi
+    else
+      echo "  ✓ $tool already installed"
+    fi
+  else
+    echo "  📦 Installing $tool..."
+    if uv tool install "$tool" 2>&1 | sed 's/^/    /'; then
+      echo "  ✓ $tool installed"
+    else
+      echo "  ⚠️  Failed to install $tool (continuing)"
+    fi
+  fi
+done
+
+echo "  ✓ iTerm2 CLI tooling setup complete"
+```
+
+- [ ] **Step 1.2: Make it executable**
+
+Run:
+```bash
+chmod +x /Users/tk/.dotfiles/iterm2/install.sh
+```
+
+Expected: no output.
+
+- [ ] **Step 1.3: Syntax-check the script**
+
+Run:
+```bash
+bash -n /Users/tk/.dotfiles/iterm2/install.sh
+```
+
+Expected: no output, exit 0.
+
+- [ ] **Step 1.4: Verify the "already installed" path (DOT_MODE unset → install semantics)**
+
+Run:
+```bash
+bash /Users/tk/.dotfiles/iterm2/install.sh
+```
+
+Expected output includes:
+```
+🖥️  Setting up iTerm2 CLI tooling...
+  ✓ it2 already installed
+  ✓ iTerm2 CLI tooling setup complete
+```
+
+(Assumes `it2` is already installed in the user's env — confirmed by `which it2` showing `/Users/tk/.local/bin/it2`.)
+
+- [ ] **Step 1.5: Verify the upgrade path (DOT_MODE=update)**
+
+Run:
+```bash
+DOT_MODE=update bash /Users/tk/.dotfiles/iterm2/install.sh
+```
+
+Expected output includes:
+```
+🖥️  Setting up iTerm2 CLI tooling...
+  🔄 Upgrading it2...
+    ...
+  ✓ it2 upgrade complete
+  ✓ iTerm2 CLI tooling setup complete
+```
+
+(`uv tool upgrade it2` prints `Nothing to upgrade` if already current — that's still exit 0 and counts as success.)
+
+- [ ] **Step 1.6: Verify the iTerm2-missing skip path**
+
+Run:
+```bash
+# Simulate missing iTerm2 by overriding the path test via a wrapper script
+DOT_MODE=install bash -c '
+  cd /Users/tk/.dotfiles
+  # Source with a faked iTerm.app check by temporarily moving the app would be destructive.
+  # Instead, verify by reading the code path:
+  grep -A 3 "Guard 1" iterm2/install.sh
+'
+```
+
+Expected: prints the guard block — confirming it returns/exits 0 before reaching uv calls. (Full live skip test would require renaming `/Applications/iTerm.app`, which is destructive to the dev environment; the code-path inspection here is sufficient — the spec's test plan #4 covers full verification on systems without iTerm2.)
+
+- [ ] **Step 1.7: Commit**
+
+```bash
+git -C /Users/tk/.dotfiles add iterm2/install.sh
+git -C /Users/tk/.dotfiles commit -m "feat: add iterm2 topic installer for it2 uv tool
+
+Adds iterm2/install.sh that installs the it2 CLI via uv tool
+when iTerm2 is present and missing, and upgrades it when
+DOT_MODE=update. Gated on iTerm2 presence and uv availability."
+```
+
+Expected: commit succeeds.
+
+---
+
+## Task 2: Wire `iterm2/install.sh` into `cmd_install`
+
+**Files:**
+- Modify: `bin/dot` (insert after the FNM block, before the zsh installer block)
+
+- [ ] **Step 2.1: Locate the insertion site**
+
+Run:
+```bash
+grep -n "Run zsh installer" /Users/tk/.dotfiles/bin/dot
+```
+
+Expected: returns one line, around line 352. The insertion goes immediately above this line (after the closing `fi` of the FNM block at line 350).
+
+- [ ] **Step 2.2: Insert the iTerm2 installer source**
+
+In `bin/dot`, find this block:
+
+```bash
+		fi
+	fi
+
+	# Run zsh installer
+	if [ -f "$DOTFILES/zsh/install.sh" ]; then
+		source "$DOTFILES/zsh/install.sh"
+	fi
+```
+
+Replace with:
+
+```bash
+		fi
+	fi
+
+	# Run iTerm2 installer
+	if [ -f "$DOTFILES/iterm2/install.sh" ]; then
+		DOT_MODE=install source "$DOTFILES/iterm2/install.sh"
+	fi
+
+	# Run zsh installer
+	if [ -f "$DOTFILES/zsh/install.sh" ]; then
+		source "$DOTFILES/zsh/install.sh"
+	fi
+```
+
+- [ ] **Step 2.3: Syntax-check `bin/dot`**
+
+Run:
+```bash
+bash -n /Users/tk/.dotfiles/bin/dot
+```
+
+Expected: no output, exit 0.
+
+- [ ] **Step 2.4: Verify the install branch executes correctly via dry-run trace**
+
+Run:
+```bash
+grep -B 1 -A 3 "iterm2/install.sh" /Users/tk/.dotfiles/bin/dot
+```
+
+Expected output (one match, in `cmd_install`):
+```
+	# Run iTerm2 installer
+	if [ -f "$DOTFILES/iterm2/install.sh" ]; then
+		DOT_MODE=install source "$DOTFILES/iterm2/install.sh"
+	fi
+```
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git -C /Users/tk/.dotfiles add bin/dot
+git -C /Users/tk/.dotfiles commit -m "feat(dot): source iterm2/install.sh in cmd_install
+
+Sources the new iterm2/install.sh with DOT_MODE=install after the
+FNM block and before zsh installer, so iTerm2 cask (from Brewfile)
+is on disk before it2 is installed."
+```
+
+Expected: commit succeeds.
+
+---
+
+## Task 3: Wire `iterm2/install.sh` into `cmd_update`
+
+**Files:**
+- Modify: `bin/dot` (insert after the brew bundle check + node cleanup blocks, before npm globals update block)
+
+- [ ] **Step 3.1: Locate the insertion site**
+
+Run:
+```bash
+grep -n "Cleanup complete\|Updating npm global\|Update npm global packages" /Users/tk/.dotfiles/bin/dot
+```
+
+Expected: returns lines around 444, 447 (cleanup complete), and 456 (npm globals header). The insertion goes immediately after the `brew cleanup` block ends (after the `✓ Cleanup complete` echo) and before the `# Update npm global packages` comment.
+
+- [ ] **Step 3.2: Insert the iTerm2 installer source**
+
+In `bin/dot` `cmd_update`, find this block:
+
+```bash
+	echo ""
+	echo "🧹 Cleaning up Homebrew..."
+	brew cleanup
+	echo -e "  ${GREEN}✓ Cleanup complete${NC}"
+
+	# Update npm global packages (if FNM/Node is available)
+	if command -v npm &> /dev/null; then
+```
+
+Replace with:
+
+```bash
+	echo ""
+	echo "🧹 Cleaning up Homebrew..."
+	brew cleanup
+	echo -e "  ${GREEN}✓ Cleanup complete${NC}"
+
+	# Run iTerm2 installer in update mode
+	if [ -f "$DOTFILES/iterm2/install.sh" ]; then
+		DOT_MODE=update source "$DOTFILES/iterm2/install.sh"
+	fi
+
+	# Update npm global packages (if FNM/Node is available)
+	if command -v npm &> /dev/null; then
+```
+
+- [ ] **Step 3.3: Syntax-check `bin/dot`**
+
+Run:
+```bash
+bash -n /Users/tk/.dotfiles/bin/dot
+```
+
+Expected: no output, exit 0.
+
+- [ ] **Step 3.4: Verify both install and update sites are wired**
+
+Run:
+```bash
+grep -c "iterm2/install.sh" /Users/tk/.dotfiles/bin/dot
+```
+
+Expected: `2`
+
+Run:
+```bash
+grep "DOT_MODE=" /Users/tk/.dotfiles/bin/dot
+```
+
+Expected output (two lines):
+```
+		DOT_MODE=install source "$DOTFILES/iterm2/install.sh"
+		DOT_MODE=update source "$DOTFILES/iterm2/install.sh"
+```
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git -C /Users/tk/.dotfiles add bin/dot
+git -C /Users/tk/.dotfiles commit -m "feat(dot): source iterm2/install.sh in cmd_update with DOT_MODE=update
+
+Self-heals it2 if missing during dot update, and upgrades it
+to the latest version. First topic installer sourced from
+cmd_update — establishes the DOT_MODE=update convention."
+```
+
+Expected: commit succeeds.
+
+---
+
+## Task 4: Document the new topic in `CLAUDE.md`
+
+**Files:**
+- Modify: `CLAUDE.md` (insert new subsection under "Important Notes")
+
+- [ ] **Step 4.1: Find the "Claude MCP Servers" subsection — we'll add the iTerm2 subsection right above it**
+
+Run:
+```bash
+grep -n "^### Claude MCP Servers" /Users/tk/.dotfiles/CLAUDE.md
+```
+
+Expected: returns one line.
+
+- [ ] **Step 4.2: Insert the iTerm2 subsection**
+
+In `CLAUDE.md`, find this line:
+
+```markdown
+### Claude MCP Servers
+```
+
+Insert immediately above it:
+
+```markdown
+### iTerm2 CLI Tooling
+
+The `iterm2/` topic installs uv-managed CLI tools that complement iTerm2 (e.g., `it2`):
+
+- Gated on iTerm2 being installed at `/Applications/iTerm.app` (skips silently otherwise)
+- Gated on `uv` being available (Brewfile guarantees this)
+- Tools listed in the `UV_TOOLS=("it2")` array inside `iterm2/install.sh` — add entries to extend
+- Runs in both `dot install` and `dot update`:
+  - `dot install` (DOT_MODE=install): installs missing tools
+  - `dot update` (DOT_MODE=update): installs missing tools and upgrades existing ones
+- Failures on a single tool emit a warning and continue — never abort the broader `dot` run
+
+**Adding more uv tools:**
+
+- Edit `UV_TOOLS=()` in `iterm2/install.sh` and re-run `dot install` or `dot update`
+
+### Claude MCP Servers
+```
+
+- [ ] **Step 4.3: Verify the doc renders**
+
+Run:
+```bash
+grep -A 2 "^### iTerm2 CLI Tooling" /Users/tk/.dotfiles/CLAUDE.md
+```
+
+Expected output:
+```
+### iTerm2 CLI Tooling
+
+The `iterm2/` topic installs uv-managed CLI tools that complement iTerm2 (e.g., `it2`):
+```
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git -C /Users/tk/.dotfiles add CLAUDE.md
+git -C /Users/tk/.dotfiles commit -m "docs: document iterm2 topic and UV_TOOLS extension pattern"
+```
+
+Expected: commit succeeds.
+
+---
+
+## Task 5: Add changeset entry
+
+**Files:**
+- Create: `.changeset/iterm2-it2-installer.md`
+
+- [ ] **Step 5.1: Create the changeset file**
+
+Write file `/Users/tk/.dotfiles/.changeset/iterm2-it2-installer.md` with this exact content:
+
+```markdown
+---
+'tk-dotfiles': minor
+---
+
+Add iterm2 topic installer that auto-installs the it2 CLI via uv tool when iTerm2 is present, and upgrades it on dot update. Introduces a DOT_MODE env signal so topic installers can branch on install vs update lifecycle.
+```
+
+- [ ] **Step 5.2: Verify the changeset format**
+
+Run:
+```bash
+cat /Users/tk/.dotfiles/.changeset/iterm2-it2-installer.md
+```
+
+Expected: prints exactly the content above.
+
+- [ ] **Step 5.3: Run pnpm format to align with repo style**
+
+Run:
+```bash
+cd /Users/tk/.dotfiles && pnpm format
+```
+
+Expected: prints formatted file count, no errors. Re-formats the changeset file if needed.
+
+- [ ] **Step 5.4: Commit**
+
+```bash
+git -C /Users/tk/.dotfiles add .changeset/iterm2-it2-installer.md
+git -C /Users/tk/.dotfiles commit -m "chore: add changeset for iterm2 it2 installer"
+```
+
+Expected: commit succeeds.
+
+---
+
+## Task 6: End-to-end verification
+
+**Files:** none (read-only verification)
+
+- [ ] **Step 6.1: Run `dot update` end-to-end**
+
+Run:
+```bash
+/Users/tk/.dotfiles/bin/dot update
+```
+
+Expected behavior in output:
+- Standard `dot update` flow runs (symlinks, brew, etc.)
+- After `🧹 Cleaning up Homebrew...` block, see:
+  ```
+  🖥️  Setting up iTerm2 CLI tooling...
+    🔄 Upgrading it2...
+      ...
+    ✓ it2 upgrade complete
+    ✓ iTerm2 CLI tooling setup complete
+  ```
+- npm globals block runs after (or skips if `NPM_GLOBALS` is empty)
+- Final "Update complete" banner
+
+Confirm exit code:
+```bash
+echo $?
+```
+
+Expected: `0`
+
+- [ ] **Step 6.2: Verify `it2` still works**
+
+Run:
+```bash
+it2 --version
+```
+
+Expected: prints a version line (should match what `uv tool list` shows for `it2`).
+
+- [ ] **Step 6.3: Verify idempotency — run `dot update` again**
+
+Run:
+```bash
+/Users/tk/.dotfiles/bin/dot update
+```
+
+Expected: same iTerm2 block output as before; `uv tool upgrade it2` reports `Nothing to upgrade` or similar; exit code 0.
+
+- [ ] **Step 6.4: Final summary commit (if any incidental fixes)**
+
+If any small fix was needed during verification (e.g., output formatting, typo), commit it. Otherwise skip.
+
+---
+
+## Self-review checklist (executed by plan author)
+
+- ✅ Spec coverage:
+  - Goal #1 (install on `dot install` if missing) → Task 1 + Task 2
+  - Goal #2 (install/upgrade on `dot update`) → Task 1 + Task 3
+  - Goal #3 (skip silently if iTerm2 missing) → Task 1 (Guard 1)
+  - Goal #4 (extensible via array) → Task 1 (`UV_TOOLS=("it2")`)
+  - `$DOT_MODE` env convention → Task 2 + Task 3
+  - Output style mirrors `claude/install.sh` → Task 1 (✓/⚠️/⏩ prefixes)
+  - Documentation update → Task 4
+  - Test plan → Task 1 verification steps + Task 6 end-to-end
+- ✅ Placeholder scan: every step contains exact code, exact paths, exact commands
+- ✅ Type consistency: `UV_TOOLS`, `DOT_MODE`, `iterm2/install.sh` named identically across all tasks
+- ✅ Skipped formal TDD: no test framework in repo; verification is concrete commands with expected output, matching project convention

--- a/docs/superpowers/specs/2026-04-27-iterm2-it2-installer-design.md
+++ b/docs/superpowers/specs/2026-04-27-iterm2-it2-installer-design.md
@@ -90,13 +90,13 @@ The `uv tool list` output prefixes each tool name with `<name> v<version>` at th
 
 ## Error handling
 
-| Condition | Behavior |
-|---|---|
-| iTerm2 missing | Skip silently with `⏩` line, exit 0 |
-| `uv` missing | Warn with `⚠️` line, exit 0 |
-| Single `uv tool install` fails (e.g., network) | Print warning, continue with next tool, don't abort `dot` |
-| Single `uv tool upgrade` fails | Same as above |
-| `uv tool list` parse error | Treat as "not installed" — install path will retry; failures are surfaced there |
+| Condition                                      | Behavior                                                                        |
+| ---------------------------------------------- | ------------------------------------------------------------------------------- |
+| iTerm2 missing                                 | Skip silently with `⏩` line, exit 0                                            |
+| `uv` missing                                   | Warn with `⚠️` line, exit 0                                                     |
+| Single `uv tool install` fails (e.g., network) | Print warning, continue with next tool, don't abort `dot`                       |
+| Single `uv tool upgrade` fails                 | Same as above                                                                   |
+| `uv tool list` parse error                     | Treat as "not installed" — install path will retry; failures are surfaced there |
 
 ## Documentation updates
 

--- a/docs/superpowers/specs/2026-04-27-iterm2-it2-installer-design.md
+++ b/docs/superpowers/specs/2026-04-27-iterm2-it2-installer-design.md
@@ -1,0 +1,115 @@
+# iTerm2 `it2` CLI Auto-Installer — Design
+
+**Date:** 2026-04-27
+**Status:** Approved (design); plan pending
+**Owner:** Tony Kornmeier
+
+## Problem
+
+The `it2` CLI (iTerm2's Python-based control tool) is currently installed manually via `uv tool install it2`. The dotfiles repo already manages iTerm2 itself (Brewfile cask) but has no automation for the companion CLI. We want the `dot` workflow to install `it2` automatically when iTerm2 is present and keep it current on subsequent updates.
+
+## Goals
+
+1. `dot install` installs `it2` via `uv tool install it2` if iTerm2 is installed and `it2` is missing.
+2. `dot update` installs `it2` if missing, and upgrades it if already installed.
+3. If iTerm2 is not installed, the installer skips silently — never fails `dot install` or `dot update`.
+4. The installer is extensible to other iTerm2-related uv tools via a single array.
+
+## Non-Goals
+
+- Generic uv-tool framework usable across unrelated topics. (YAGNI; today this is iTerm2-scoped.)
+- Fixing the orphaned `claude/install.sh` wiring. Noted as a follow-up; out of scope here.
+- Managing iTerm2 itself — that stays in the Brewfile.
+- Pinning specific `it2` versions.
+
+## Design
+
+### File layout
+
+```
+iterm2/
+└── install.sh          # new
+```
+
+This mirrors the existing topic convention (`claude/`, `fnm/`, `tmux/`, `zsh/`, `macos/`).
+
+### Script contract
+
+`iterm2/install.sh` is a sourced bash script (consistent with peers). It:
+
+1. **Guards** on iTerm2 presence: `[ -d "/Applications/iTerm.app" ]`. If absent, prints `⏩ iTerm2 not installed, skipping it2 setup` and exits 0.
+2. **Guards** on `uv` availability: `command -v uv`. If absent, prints `⚠️ uv not found — install via Brewfile` and exits 0. (Defensive — Brewfile guarantees it during `dot install`.)
+3. Defines `UV_TOOLS=("it2")` — single source of truth, extensible by adding entries.
+4. Iterates `UV_TOOLS`. For each tool:
+   - Detect installed state via `uv tool list` (parsed for `^<tool> ` line prefix).
+   - If missing: `uv tool install <tool>`.
+   - If installed and `$DOT_MODE` = `update`: `uv tool upgrade <tool>`.
+   - If installed and `$DOT_MODE` ≠ `update`: print `✓ <tool> already installed` and continue.
+5. Each `uv tool install/upgrade` call uses `|| true` chaining (or equivalent) so a single tool failure doesn't abort the rest of `dot install`/`dot update`.
+
+### Mode signaling
+
+`bin/dot` exports `DOT_MODE=install` before sourcing the installer from `cmd_install`, and `DOT_MODE=update` before sourcing from `cmd_update`. The script reads `$DOT_MODE` to decide upgrade behavior. Default (unset) is treated as `install` semantics.
+
+### Wiring into `bin/dot`
+
+**`cmd_install`** — source `iterm2/install.sh` after the FNM block (which begins around line 276) and before the zsh installer (around line 353). This places it after `brew bundle install` (which provides iTerm2 and uv) and after FNM Node setup (no dependency, but matches the topic-installer flow).
+
+**`cmd_update`** — source `iterm2/install.sh` after the `brew bundle check` self-heal block (which ends around line 431) and before the npm globals update block (around line 447). This is the first topic installer ever sourced from `cmd_update`; the convention being established is "topic installers are safe to run in update mode and read `$DOT_MODE` for branching."
+
+### Output style
+
+Match `claude/install.sh` conventions:
+
+- Emoji-prefixed banner line at start (e.g., `🖥️  Setting up iTerm2 CLI tooling...`).
+- Two-space indented status lines using `✓` (success), `⚠️` (warning), `⏩` (skip).
+- Closing summary line only if at least one tool was acted on.
+
+## Detection logic detail
+
+```bash
+# iTerm2 presence
+if [ ! -d "/Applications/iTerm.app" ]; then
+    echo "⏩ iTerm2 not installed, skipping it2 setup"
+    exit 0
+fi
+
+# uv availability
+if ! command -v uv &> /dev/null; then
+    echo "⚠️  uv not found — install via Brewfile"
+    exit 0
+fi
+
+# tool installed?
+if uv tool list 2>/dev/null | grep -q "^${tool} "; then
+    # installed
+fi
+```
+
+The `uv tool list` output prefixes each tool name with `<name> v<version>` at the start of a line, so `^<tool> ` is a stable parse target.
+
+## Error handling
+
+| Condition | Behavior |
+|---|---|
+| iTerm2 missing | Skip silently with `⏩` line, exit 0 |
+| `uv` missing | Warn with `⚠️` line, exit 0 |
+| Single `uv tool install` fails (e.g., network) | Print warning, continue with next tool, don't abort `dot` |
+| Single `uv tool upgrade` fails | Same as above |
+| `uv tool list` parse error | Treat as "not installed" — install path will retry; failures are surfaced there |
+
+## Documentation updates
+
+`CLAUDE.md` gets a new subsection under "Topic-Based Organization" describing the `iterm2/` topic and the `UV_TOOLS` extension pattern. No README changes required.
+
+## Test plan
+
+1. **Fresh-state install** — uninstall `it2` (`uv tool uninstall it2`), run `dot install`, confirm `it2` is reinstalled and `it2 --version` works.
+2. **Idempotent install** — run `dot install` again with `it2` already present, confirm `✓ it2 already installed` and no re-install.
+3. **Upgrade on update** — run `dot update`, confirm either `✓ it2 already up to date` (if at latest) or upgrade output.
+4. **Missing iTerm2** — temporarily rename `/Applications/iTerm.app` (or test on a machine without it), run `dot update`, confirm skip line and zero exit.
+5. **Missing uv** — simulate by running script with `PATH` stripped of `/usr/local/bin` and `/opt/homebrew/bin`, confirm `⚠️ uv not found` warn-and-skip.
+
+## Follow-ups (out of scope)
+
+- `claude/install.sh` is currently defined but not sourced from `bin/dot` (`cmd_install` skips it; `cmd_update` doesn't source any topic installers). Wiring it in would benefit from the same `$DOT_MODE` convention introduced here. Track separately.

--- a/iterm2/install.sh
+++ b/iterm2/install.sh
@@ -30,7 +30,8 @@ for tool in "${UV_TOOLS[@]}"; do
   if uv tool list 2>/dev/null | grep -q "^${tool} "; then
     if [ "$DOT_MODE" = "update" ]; then
       echo "  🔄 Upgrading $tool..."
-      if uv tool upgrade "$tool" 2>&1 | sed 's/^/    /'; then
+      uv tool upgrade "$tool" 2>&1 | sed 's/^/    /'
+      if [ "${PIPESTATUS[0]}" -eq 0 ]; then
         echo "  ✓ $tool upgrade complete"
       else
         echo "  ⚠️  Failed to upgrade $tool (continuing)"
@@ -40,7 +41,8 @@ for tool in "${UV_TOOLS[@]}"; do
     fi
   else
     echo "  📦 Installing $tool..."
-    if uv tool install "$tool" 2>&1 | sed 's/^/    /'; then
+    uv tool install "$tool" 2>&1 | sed 's/^/    /'
+    if [ "${PIPESTATUS[0]}" -eq 0 ]; then
       echo "  ✓ $tool installed"
     else
       echo "  ⚠️  Failed to install $tool (continuing)"

--- a/iterm2/install.sh
+++ b/iterm2/install.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# iTerm2 CLI tooling installer
+# Installs uv-managed CLI tools that complement iTerm2 (e.g., it2).
+# Sourced by bin/dot from cmd_install and cmd_update.
+# Reads $DOT_MODE (install|update) to branch upgrade behavior.
+
+echo ""
+echo "🖥️  Setting up iTerm2 CLI tooling..."
+
+# Guard 1: iTerm2 must be installed
+if [ ! -d "/Applications/iTerm.app" ]; then
+  echo "  ⏩ iTerm2 not installed, skipping it2 setup"
+  return 0 2>/dev/null || exit 0
+fi
+
+# Guard 2: uv must be available (Brewfile guarantees it during dot install)
+if ! command -v uv &> /dev/null; then
+  echo "  ⚠️  uv not found — install via Brewfile"
+  return 0 2>/dev/null || exit 0
+fi
+
+# Tools to install via `uv tool install`. Add entries to extend.
+UV_TOOLS=("it2")
+
+# Default mode is install if not set
+DOT_MODE="${DOT_MODE:-install}"
+
+for tool in "${UV_TOOLS[@]}"; do
+  if uv tool list 2>/dev/null | grep -q "^${tool} "; then
+    if [ "$DOT_MODE" = "update" ]; then
+      echo "  🔄 Upgrading $tool..."
+      if uv tool upgrade "$tool" 2>&1 | sed 's/^/    /'; then
+        echo "  ✓ $tool upgrade complete"
+      else
+        echo "  ⚠️  Failed to upgrade $tool (continuing)"
+      fi
+    else
+      echo "  ✓ $tool already installed"
+    fi
+  else
+    echo "  📦 Installing $tool..."
+    if uv tool install "$tool" 2>&1 | sed 's/^/    /'; then
+      echo "  ✓ $tool installed"
+    else
+      echo "  ⚠️  Failed to install $tool (continuing)"
+    fi
+  fi
+done
+
+echo "  ✓ iTerm2 CLI tooling setup complete"

--- a/tmux/aliases.zsh
+++ b/tmux/aliases.zsh
@@ -11,4 +11,4 @@ alias tkss='tmux kill-session -t'
 # prompting for user confirmation. Only use this in trusted, sandboxed
 # environments. Do not source this file on shared or production machines.
 # Claude Code Orchestration
-alias cldyo='export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 && claude --verbose --dangerously-skip-permissions --model opus --teammate-mode tmux'
+alias cldyo='export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 && claude --dangerously-skip-permissions --model opus --teammate-mode tmux'


### PR DESCRIPTION
## Summary

- New `iterm2/` topic installs and upgrades [`it2`](https://github.com/gnachman/iTerm2/tree/master/api/library/python) (iTerm2's CLI) via `uv tool` automatically when iTerm2 is present at `/Applications/iTerm.app`
- Sourced from `bin/dot`'s `cmd_install` (`DOT_MODE=install`) and `cmd_update` (`DOT_MODE=update`) — first topic installer to run in update mode, establishing a `$DOT_MODE` convention reusable by the orphaned `claude/install.sh` later
- `UV_TOOLS=("it2")` array makes adding more iTerm2-related uv tools a one-line change
- Spec: `docs/superpowers/specs/2026-04-27-iterm2-it2-installer-design.md`
- Plan: `docs/superpowers/plans/2026-04-27-iterm2-it2-installer.md`

## Test plan

- [ ] Run `dot update` end-to-end — verify the `🖥️  Setting up iTerm2 CLI tooling...` block appears between brew cleanup and the final summary, with exit 0
- [ ] Run `dot update` again — verify idempotent (same output, no errors)
- [ ] Run `it2 --version` — confirms tool still works after upgrade pass
- [ ] (Optional, destructive) Uninstall: `uv tool uninstall it2`, then `dot install` — verify reinstall path fires
- [ ] Code-path inspection of guards: `grep -A 3 "Guard" iterm2/install.sh` — both iTerm2 and uv guards return 0 before reaching `uv` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)