### PR TITLE
feat(herdr): add herdr topic installer to dot workflow

### DIFF
--- a/.changeset/herdr-installer.md
+++ b/.changeset/herdr-installer.md
@@ -1,0 +1,5 @@
+---
+'tk-dotfiles': minor
+---
+
+Add herdr topic installer that auto-installs the herdr CLI via the upstream curl installer when missing, and self-updates it via the built-in `herdr update` command on dot update.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,17 @@ The `iterm2/` topic installs uv-managed CLI tools that complement iTerm2 (e.g., 
 
 - Edit `UV_TOOLS=()` in `iterm2/install.sh` and re-run `dot install` or `dot update`
 
+### herdr CLI
+
+The `herdr/` topic installs the `herdr` CLI (terminal workspace manager for AI coding agents), which is distributed only via a curl installer (not Homebrew):
+
+- Installed via `curl -fsSL https://herdr.dev/install.sh | sh` (binary lands in `~/.local/bin`, already on `$PATH` via `system/path.zsh`)
+- Detection uses `command -v herdr`
+- Runs in both `dot install` and `dot update`:
+  - `dot install` (DOT_MODE=install): installs herdr if missing, otherwise skips
+  - `dot update` (DOT_MODE=update): installs if missing, otherwise self-updates via the built-in `herdr update` command
+- Failures emit a warning and continue — never abort the broader `dot` run
+
 ### Claude MCP Servers
 
 The `claude/` topic configures Model Context Protocol (MCP) servers for Claude Desktop and Claude Code:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,7 @@ The `iterm2/` topic installs uv-managed CLI tools that complement iTerm2 (e.g., 
 
 The `herdr/` topic installs the `herdr` CLI (terminal workspace manager for AI coding agents), which is distributed only via a curl installer (not Homebrew):
 
-- Installed via `curl -fsSL https://herdr.dev/install.sh | sh` (binary lands in `~/.local/bin`, already on `$PATH` via `system/path.zsh`)
+- Installed via `curl -fsSL https://herdr.dev/install.sh | sh` (binary lands in `~/.local/bin`; `system/path.zsh` adds that directory to `$PATH` for the user's zsh shell, so `herdr` is available in normal terminal use after a shell restart)
 - Detection uses `command -v herdr`
 - Runs in both `dot install` and `dot update`:
   - `dot install` (DOT_MODE=install): installs herdr if missing, otherwise skips

--- a/bin/dot
+++ b/bin/dot
@@ -354,6 +354,11 @@ cmd_install() {
 		DOT_MODE=install source "$DOTFILES/iterm2/install.sh"
 	fi
 
+	# Run herdr installer
+	if [ -f "$DOTFILES/herdr/install.sh" ]; then
+		DOT_MODE=install source "$DOTFILES/herdr/install.sh"
+	fi
+
 	# Run zsh installer
 	if [ -f "$DOTFILES/zsh/install.sh" ]; then
 		source "$DOTFILES/zsh/install.sh"
@@ -452,6 +457,11 @@ cmd_update() {
 	# Run iTerm2 installer in update mode
 	if [ -f "$DOTFILES/iterm2/install.sh" ]; then
 		DOT_MODE=update source "$DOTFILES/iterm2/install.sh"
+	fi
+
+	# Run herdr installer in update mode
+	if [ -f "$DOTFILES/herdr/install.sh" ]; then
+		DOT_MODE=update source "$DOTFILES/herdr/install.sh"
 	fi
 
 	# Update npm global packages (if FNM/Node is available)

--- a/herdr/install.sh
+++ b/herdr/install.sh
@@ -27,7 +27,9 @@ if command -v herdr &> /dev/null; then
 else
   echo "  📦 Installing herdr..."
   curl -fsSL https://herdr.dev/install.sh | sh 2>&1 | sed 's/^/    /'
-  if command -v herdr &> /dev/null; then
+  # PIPESTATUS indices: [0]=curl, [1]=sh installer, [2]=sed
+  installer_status="${PIPESTATUS[1]}"
+  if [ "$installer_status" -eq 0 ] && [ -x "$HOME/.local/bin/herdr" ]; then
     echo "  ✓ herdr installed"
   else
     echo "  ⚠️  Failed to install herdr (continuing)"

--- a/herdr/install.sh
+++ b/herdr/install.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# herdr installer
+# Installs the herdr CLI (terminal workspace manager for AI coding agents)
+# via the upstream curl installer, and self-updates it via `herdr update`.
+# Sourced by bin/dot from cmd_install and cmd_update.
+# Reads $DOT_MODE (install|update) to branch upgrade behavior.
+
+echo ""
+echo "🐂 Setting up herdr..."
+
+# Default mode is install if not set
+DOT_MODE="${DOT_MODE:-install}"
+
+if command -v herdr &> /dev/null; then
+  if [ "$DOT_MODE" = "update" ]; then
+    echo "  🔄 Updating herdr..."
+    herdr update 2>&1 | sed 's/^/    /'
+    if [ "${PIPESTATUS[0]}" -eq 0 ]; then
+      echo "  ✓ herdr update complete"
+    else
+      echo "  ⚠️  Failed to update herdr (continuing)"
+    fi
+  else
+    echo "  ✓ herdr already installed"
+  fi
+else
+  echo "  📦 Installing herdr..."
+  curl -fsSL https://herdr.dev/install.sh | sh 2>&1 | sed 's/^/    /'
+  if command -v herdr &> /dev/null; then
+    echo "  ✓ herdr installed"
+  else
+    echo "  ⚠️  Failed to install herdr (continuing)"
+  fi
+fi
+
+echo "  ✓ herdr setup complete"


### PR DESCRIPTION
## Summary

Adds a `herdr/` topic that brings the [herdr](https://herdr.dev) CLI (terminal workspace manager for AI coding agents) into the `dot` install/update workflow. herdr is distributed only via a curl installer — no Homebrew formula — so it gets a topic `install.sh` like `fnm/` and `iterm2/`.

## Behavior

- `dot install` / `dot bootstrap` — installs herdr via `curl -fsSL https://herdr.dev/install.sh | sh` if `command -v herdr` fails; otherwise skips.
- `dot` / `dot update` — installs if missing, otherwise self-updates via herdr's built-in `herdr update` command.
- Failures warn and continue — never abort the broader `dot` run.

Wired into `bin/dot`'s `cmd_install` and `cmd_update` using the existing `DOT_MODE` branching pattern, mirroring `iterm2/install.sh`.

## Changes

- `herdr/install.sh` (new) — topic installer
- `bin/dot` — two `source` lines (install + update modes)
- `CLAUDE.md` — new `### herdr CLI` doc section
- `.changeset/herdr-installer.md` — `minor` bump

## Testing

- `bash -n` clean on `herdr/install.sh` and `bin/dot`
- Install-mode run correctly detected an existing install and skipped (no side effects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)