### PR TITLE
chore: update brewfile to remove unused terminal apps

### DIFF
--- a/.changeset/olive-places-pay.md
+++ b/.changeset/olive-places-pay.md
@@ -1,0 +1,5 @@
+---
+'tk-dotfiles': patch
+---
+
+chore: update brewfile

--- a/Brewfile
+++ b/Brewfile
@@ -11,15 +11,15 @@ brew 'findutils'
 brew 'ack' # a grep-like source code search tool
 brew 'act' # GitHub Actions runner
 brew 'bun' # Node package manager
+brew 'fnm' # Node.js version manager and corepack installer
 brew 'gcc' # the GNU Compiler
+brew 'gh' # GitHub official CLI (replaces deprecated hub)
 brew 'git-delta' # syntax-highlighting pager for git and diff output
 brew 'git' # distributed revision control system
 brew 'go' # go programming language
 brew 'gpg' # GNU Privacy Guard
 brew 'grc' # colorize logfiles and command output
-brew 'fnm' # Node.js version manager and corepack installer
 # NOTE: If any formula installs node as a dependency, it will be removed by fnm/install.sh and bin/dot
-brew 'gh' # GitHub official CLI (replaces deprecated hub)
 brew 'imagemagick' # Image manipulation library
 brew 'jq' # Lightweight and flexible command-line JSON processor
 brew 'just' # Task runner
@@ -27,7 +27,7 @@ brew 'libgit2' # C library of Git core methods that is re-entrant and linkable
 brew 'mas' # CLI for installing app from Mac App Store
 brew 'mongodb-community', restart_service: false # NoSQL database (manual start: brew services start mongodb-community)
 brew 'openssl' # Cryptography and SSL/TLS Toolkit
-brew 'pi-coding-agent' # Customize agent harness
+# brew 'pi-coding-agent' # Customize agent harness
 brew 'postgresql', restart_service: false # SQL database (manual start: brew services start postgresql)
 brew 'pyenv' # Python virtual env
 brew 'readline' # Library for command-line editing
@@ -50,6 +50,7 @@ cask 'claude-code@latest' # AI programming friend
 cask 'cmux' # Ghostty-based terminal with vertical tabs
 cask 'cursor' # Write, edit, and chat about your code with AI
 cask 'discord' # VoIP and chat app
+cask 'docker-desktop' # Build containerised applications and microservices
 cask 'firefox' # Web browser
 cask 'font-fira-code-nerd-font' # Monospace font with programming ligatures
 cask 'font-jetbrains-mono-nerd-font' # Monospace font with programming ligatures

--- a/tmux/aliases.zsh
+++ b/tmux/aliases.zsh
@@ -10,5 +10,6 @@ alias tkss='tmux kill-session -t'
 # Claude Code to execute tools (shell commands, file writes, etc.) without
 # prompting for user confirmation. Only use this in trusted, sandboxed
 # environments. Do not source this file on shared or production machines.
+
 # Claude Code Orchestration
 alias cldyo='export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 && claude --dangerously-skip-permissions --model opus --teammate-mode tmux'


### PR DESCRIPTION
This pull request makes minor updates to the development environment setup files. It adjusts the order and commenting of some Homebrew formulas, adds Docker Desktop to the cask installations, and makes a minor formatting change to the tmux aliases.

Development environment updates:

* Reordered `brew 'fnm'` and `brew 'gh'` in the `Brewfile` for better organization and commented out `brew 'pi-coding-agent'` to disable its installation.
* Added `cask 'docker-desktop'` to the `Brewfile` to support containerized application development.

Other changes:

* Added a blank line for clarity in `tmux/aliases.zsh` before the Claude Code orchestration alias.