### PR TITLE
fix(path): put $DOTFILES/bin ahead of /usr/local/bin

### DIFF
--- a/.changeset/tidy-paths-resolve.md
+++ b/.changeset/tidy-paths-resolve.md
@@ -1,0 +1,5 @@
+---
+'tk-dotfiles': patch
+---
+
+Fix `gsync` resolving to GNU `sync` from Homebrew coreutils instead of `bin/gsync`. `$DOTFILES/bin` now precedes `/usr/local/bin` in `$PATH`, and the relative `./bin` entry was removed so scripts in an arbitrary repo's `bin/` directory are no longer on `$PATH` by name.

--- a/system/path.zsh
+++ b/system/path.zsh
@@ -1,2 +1,2 @@
 export PATH="/opt/homebrew/bin:$PATH"
-export PATH="./bin:$HOME/bin:$HOME/.local/bin:/usr/local/bin:/usr/local/sbin:$DOTFILES/bin:$PATH"
+export PATH="$DOTFILES/bin:$HOME/bin:$HOME/.local/bin:/usr/local/bin:/usr/local/sbin:$PATH"


### PR DESCRIPTION
## Problem

`gsync` was silently doing nothing. The script was fine — the name was shadowed.

Homebrew's `coreutils` installs every GNU tool with a `g` prefix, including `gsync` (GNU `sync`) at `/usr/local/bin/gsync`. That directory sat **ahead** of `$DOTFILES/bin` in `system/path.zsh`, so running `gsync` outside the dotfiles repo flushed filesystem write buffers and exited 0.

It appeared to work inside `~/.dotfiles` only because the relative `./bin` entry was first in `$PATH` and resolved to `./bin/gsync`.

## Fix

```diff
-export PATH="./bin:$HOME/bin:$HOME/.local/bin:/usr/local/bin:/usr/local/sbin:$DOTFILES/bin:$PATH"
+export PATH="$DOTFILES/bin:$HOME/bin:$HOME/.local/bin:/usr/local/bin:/usr/local/sbin:$PATH"
```

- `$DOTFILES/bin` now precedes `/usr/local/bin`, so dotfiles scripts win over Homebrew shims.
- Dropped the relative `./bin` entry — it put any repo's `bin/` scripts on `$PATH` by name just by `cd`ing into it.

## Verification

From `~` in a fresh interactive zsh:

```
command -v gsync  →  /Users/tk/.dotfiles/bin/gsync   (was /usr/local/bin/gsync)
command -v gls    →  /usr/local/bin/gls              (coreutils unaffected)
```

`bin/gsync` itself passes `bash -n`; bash 5.3 is installed so its `mapfile` usage is fine.

## Note

GNU `sync` is now shadowed by `bin/gsync`. Invoke it by full path if ever needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)