### PR TITLE
feat: add new casks for cmux and token savings

### DIFF
--- a/.changeset/silver-wings-learn.md
+++ b/.changeset/silver-wings-learn.md
@@ -1,0 +1,5 @@
+---
+'tk-dotfiles': minor
+---
+
+Add cmux and rtk to homebrew

--- a/Brewfile
+++ b/Brewfile
@@ -1,7 +1,6 @@
 cask_args appdir: '/Applications'
 
 tap 'manaflow-ai/cmux'
-tap 'mongodb/brew'
 tap 'oven-sh/bun'
 
 # gnu stuff

--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,6 @@
 cask_args appdir: '/Applications'
 
+tap 'manaflow-ai/cmux'
 tap 'mongodb/brew'
 tap 'oven-sh/bun'
 
@@ -25,13 +26,12 @@ brew 'jq' # Lightweight and flexible command-line JSON processor
 brew 'just' # Task runner
 brew 'libgit2' # C library of Git core methods that is re-entrant and linkable
 brew 'mas' # CLI for installing app from Mac App Store
-brew 'mongodb-community', restart_service: false # NoSQL database (manual start: brew services start mongodb-community)
 brew 'openssl' # Cryptography and SSL/TLS Toolkit
-# brew 'pi-coding-agent' # Customize agent harness
 brew 'postgresql', restart_service: false # SQL database (manual start: brew services start postgresql)
 brew 'pyenv' # Python virtual env
 brew 'readline' # Library for command-line editing
 brew 'redis', restart_service: false # In-memory database (manual start: brew services start redis)
+brew 'rtk' # CLI proxy to minimize LLM token consumption
 brew 'starship' # Cross-shell prompt for astronauts
 brew 'tmux' # Terminal multiplexer
 brew 'uv' # Extremely fast Python package installer and resolver
@@ -47,22 +47,24 @@ brew 'zsh' # UNIX shell (command interpreter)
 cask '1password' # Password manager
 cask 'claude' # AI programming friend
 cask 'claude-code@latest' # AI programming friend
-cask 'cmux' # Ghostty-based terminal with vertical tabs
+cask 'cmux' # Agentic-friendly terminal multiplexer
+cask 'codex' # Chad_100 in the CLI
 cask 'cursor' # Write, edit, and chat about your code with AI
 cask 'discord' # VoIP and chat app
 cask 'docker-desktop' # Build containerised applications and microservices
 cask 'firefox' # Web browser
 cask 'font-fira-code-nerd-font' # Monospace font with programming ligatures
 cask 'font-jetbrains-mono-nerd-font' # Monospace font with programming ligatures
+cask 'ghostty' # Fast terminal
 cask 'google-chrome' # Web browser
-cask 'ghostty' # Terminal emulator
 cask 'insomnia' # REST client
 cask 'iterm2' # Best terminal for agentic coding
 cask 'raycast' # Extendable launcher app
 cask 'readdle-spark' # Email client
 cask 'spotify' # Music streaming service
+cask 'supacode' # Worktree coding agents command center
+cask 'surfshark' # VPN client
 cask 'tableplus' # GUI for databases
-cask 'warp' # Terminal built for speed and safety
 cask 'zed' # Code editor
 cask 'zoom' # Video conferencing software
 

--- a/git/gitignore.symlink
+++ b/git/gitignore.symlink
@@ -3,4 +3,7 @@ dist/
 .env
 .env.*
 *.log
+logs/
 .DS_Store
+
+**/.claude/settings.local.json

--- a/tmux/aliases.zsh
+++ b/tmux/aliases.zsh
@@ -11,5 +11,5 @@ alias tkss='tmux kill-session -t'
 # prompting for user confirmation. Only use this in trusted, sandboxed
 # environments. Do not source this file on shared or production machines.
 
-# Claude Code Orchestration
+# Claude Code
 alias cldyo='claude --dangerously-skip-permissions'

--- a/tmux/aliases.zsh
+++ b/tmux/aliases.zsh
@@ -12,4 +12,4 @@ alias tkss='tmux kill-session -t'
 # environments. Do not source this file on shared or production machines.
 
 # Claude Code Orchestration
-alias cldyo='export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 && claude --dangerously-skip-permissions --model opus --teammate-mode tmux'
+alias cldyo='claude --dangerously-skip-permissions'

--- a/zsh/path.zsh
+++ b/zsh/path.zsh
@@ -5,3 +5,5 @@ case ":$PATH:" in
   *) export PATH="$PNPM_HOME:$PATH" ;;
 esac
 # pnpm end
+
+export PATH="$HOME/.bun/bin:$PATH"

--- a/zsh/path.zsh
+++ b/zsh/path.zsh
@@ -6,4 +6,9 @@ case ":$PATH:" in
 esac
 # pnpm end
 
-export PATH="$HOME/.bun/bin:$PATH"
+# bun
+case ":$PATH:" in
+  *":$HOME/.bun/bin:"*) ;;
+  *) export PATH="$PATH:$HOME/.bun/bin" ;;
+esac
+# bun end

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -144,6 +144,8 @@ export GPG_TTY=$(tty)
 
 export PATH="$HOME/.local/bin:$PATH"
 
+export PATH="$HOME/.dotnet:$PATH"
+
 # Add libpq (keg-only) to PATH for psql and other PostgreSQL client tools
 if [[ -d "$HOMEBREW_PREFIX/opt/libpq/bin" ]]; then
   export PATH="$HOMEBREW_PREFIX/opt/libpq/bin:$PATH"


### PR DESCRIPTION
This pull request updates the development environment setup with new tools and adjustments to configuration files. The main changes include adding new Homebrew taps and casks, updating CLI tool installations, and refining shell configuration for improved workflow and compatibility.

**Homebrew and toolchain updates:**

* Added the `manaflow-ai/cmux` tap and installed the `rtk` CLI tool to help minimize LLM token consumption (`Brewfile`). [[1]](diffhunk://#diff-1b33d9c13a9a1b0c5d5bc83697ba7b4d36e6cf45f78184c3a28527ffc4418e2dR3) [[2]](diffhunk://#diff-1b33d9c13a9a1b0c5d5bc83697ba7b4d36e6cf45f78184c3a28527ffc4418e2dL28-R34)
* Added several new casks: `codex` (CLI AI assistant), `ghostty` (fast terminal), `supacode` (coding agents command center), and `surfshark` (VPN client). Updated the description for `cmux` and removed duplicate `ghostty` entry (`Brewfile`).

**Shell and environment configuration:**

* Updated the `cldyo` alias to simplify the command and remove experimental environment variables (`tmux/aliases.zsh`).
* Added `$HOME/.bun/bin` and `$HOME/.dotnet` to the `PATH` for better tool compatibility (`zsh/path.zsh`, `zsh/zshrc.symlink`). [[1]](diffhunk://#diff-f0d87ff5640b72efef1324d04ef8ad8592ee13d2eae986ecfcd8ed6b22d7e8fdR8-R9) [[2]](diffhunk://#diff-4d6850c04c6a1bcc8f4667b8c199a349c1b61f4351c8d04260de56ef05a8894cR147-R148)

**Ignore rules and housekeeping:**

* Updated `.gitignore` to exclude `logs/` directories and local Claude settings files for cleaner version control (`git/gitignore.symlink`).