### PR TITLE
fix(fnm): stop dot from uninstalling Homebrew's node

### DIFF
--- a/.changeset/brave-nodes-remain.md
+++ b/.changeset/brave-nodes-remain.md
@@ -1,0 +1,5 @@
+---
+'tk-dotfiles': patch
+---
+
+Stop `dot` from uninstalling Homebrew's `node`, which broke every formula that depends on it. `brew uninstall --ignore-dependencies node` ran in `cmd_install`, `cmd_update`, and `fnm/install.sh`, so each `dot` run left `pi-coding-agent` and `mongosh` with a dangling `/opt/homebrew/opt/node/bin/node` shebang (`bad interpreter`). The removal was already obsolete: FNM's per-shell shim outranks `/opt/homebrew/bin` on `$PATH`, so Homebrew's node cannot shadow it. Also drops the `/usr/local/bin/{node,npm,npx,corepack}` symlink block from `cmd_install`, which recreated the exact symlinks `fnm/install.sh` deletes as legacy moments later in the same run.

--- a/Brewfile
+++ b/Brewfile
@@ -19,13 +19,13 @@ brew 'git' # distributed revision control system
 brew 'go' # go programming language
 brew 'gpg' # GNU Privacy Guard
 brew 'grc' # colorize logfiles and command output
-# NOTE: If any formula installs node as a dependency, it will be removed by fnm/install.sh and bin/dot
 brew 'imagemagick' # Image manipulation library
 brew 'jq' # Lightweight and flexible command-line JSON processor
 brew 'just' # Task runner
 brew 'libgit2' # C library of Git core methods that is re-entrant and linkable
 brew 'mas' # CLI for installing app from Mac App Store
 brew 'openssl' # Cryptography and SSL/TLS Toolkit
+brew 'pi-coding-agent' # Customizable agent harness
 brew 'postgresql', restart_service: false # SQL database (manual start: brew services start postgresql)
 brew 'pyenv' # Python virtual env
 brew 'readline' # Library for command-line editing

--- a/bin/dot
+++ b/bin/dot
@@ -277,13 +277,6 @@ cmd_install() {
 		echo ""
 		echo -e "${BLUE}🔧 Setting up FNM and Node.js...${NC}"
 
-		# Remove Homebrew's node if it was installed as a dependency
-		if brew list node &>/dev/null; then
-			echo -e "  ${YELLOW}⚠️  Removing Homebrew's Node (we use FNM instead)${NC}"
-			brew uninstall --ignore-dependencies node 2>/dev/null || true
-			echo -e "  ${GREEN}✓ Homebrew Node removed${NC}"
-		fi
-
 		# Set up FNM environment
 		eval "$(fnm env --use-on-cd --version-file-strategy=recursive --corepack-enabled --shell bash)"
 
@@ -297,31 +290,6 @@ cmd_install() {
 			fnm install --lts
 			fnm default lts-latest
 			echo -e "  ${GREEN}✓ Installed Node.js $(fnm current)${NC}"
-		fi
-
-		# Create or update symlinks to the default FNM Node version for system-wide access
-		SYMLINKS_NEEDED=false
-		for cmd in node npm npx corepack; do
-			if [ ! -L "/usr/local/bin/$cmd" ] || [ "$(readlink /usr/local/bin/$cmd)" != "$HOME/.local/share/fnm/aliases/default/bin/$cmd" ]; then
-				SYMLINKS_NEEDED=true
-				break
-			fi
-		done
-
-		if [ "$SYMLINKS_NEEDED" = true ]; then
-			echo ""
-			echo "  Creating symlinks for global Node.js access..."
-
-			ensure_sudo
-
-			sudo mkdir -p /usr/local/bin
-			sudo ln -sf "$HOME/.local/share/fnm/aliases/default/bin/node" /usr/local/bin/node
-			sudo ln -sf "$HOME/.local/share/fnm/aliases/default/bin/npm" /usr/local/bin/npm
-			sudo ln -sf "$HOME/.local/share/fnm/aliases/default/bin/npx" /usr/local/bin/npx
-			sudo ln -sf "$HOME/.local/share/fnm/aliases/default/bin/corepack" /usr/local/bin/corepack
-			echo -e "  ${GREEN}✓ Symlinks created${NC}"
-		else
-			echo -e "  ${GREEN}✓ Symlinks already configured correctly${NC}"
 		fi
 
 		echo -e "  ${YELLOW}- 📦 node: $(node --version)${NC}"
@@ -438,15 +406,6 @@ cmd_update() {
 		echo -e "  ${GREEN}✓ Missing packages installed${NC}"
 	else
 		echo -e "  ${GREEN}✓ All Brewfile packages are installed${NC}"
-	fi
-
-	# Remove Homebrew's node if it was installed as a dependency (we use FNM)
-	if brew list node &>/dev/null; then
-		echo ""
-		echo -e "  ${YELLOW}⚠️  Detected Homebrew Node version${NC}"
-		echo "  Removing in favor of FNM version..."
-		brew uninstall --ignore-dependencies node 2>/dev/null || true
-		echo -e "  ${GREEN}✓ Homebrew Node removed${NC}"
 	fi
 
 	echo ""

--- a/fnm/install.sh
+++ b/fnm/install.sh
@@ -21,12 +21,6 @@
 
 echo "📦 Setting up FNM and Node.js..."
 
-# Remove Homebrew's node if it was installed as a dependency
-if brew list node &>/dev/null; then
-  echo " Removing Homebrew's node (we use FNM instead)..."
-  brew uninstall --ignore-dependencies node 2>/dev/null || true
-fi
-
 # Install latest LTS version of Node.js using FNM
 echo "  Installing latest Node.js LTS version..."
 eval "$(fnm env --use-on-cd --version-file-strategy=recursive --corepack-enabled --shell bash)"


### PR DESCRIPTION
## Problem

Running `dot` broke `pi` every time:

```
/opt/homebrew/bin/pi: /opt/homebrew/Cellar/pi-coding-agent/0.82.1/libexec/bin/pi:
/opt/homebrew/opt/node/bin/node: bad interpreter: No such file or directory
```

`brew uninstall --ignore-dependencies node` ran in three places — `cmd_install`, `cmd_update`, and `fnm/install.sh`. That flag is exactly what lets it strip a dependency other formulae still need:

```
$ brew uses --installed node
mongosh
pi-coding-agent
```

Both were left with a dangling shebang. `dot` with no args defaults to `update` (`bin/dot:515`), so the plain everyday invocation hit it.

## Why the removal was obsolete

It guarded against Homebrew's node shadowing FNM on `$PATH`. 6d745b1 already fixed that properly by dropping the `/usr/local/bin` symlinks — FNM's per-shell shim now outranks `/opt/homebrew/bin`. Homebrew's own installer confirms it:

```
node (shadowed by /Users/tk/.local/state/fnm_multishells/777_.../bin/node)
```

So the uninstall solved nothing and broke two formulae.

## Changes

- Remove the three `brew uninstall --ignore-dependencies node` blocks
- Remove the `/usr/local/bin/{node,npm,npx,corepack}` symlink block from `cmd_install`, which recreated the exact symlinks `fnm/install.sh:43-49` deletes as legacy a few lines later in the same run
- Drop the now-false `Brewfile` NOTE about node being removed
- Add `brew 'pi-coding-agent'` to the Brewfile (the change that surfaced this)

Net `-48` lines of logic.

## Self-healing

Node is only ever pulled in as a dependency — there's no explicit `brew 'node'` in the Brewfile. Since `brew bundle install` runs on every `dot install`/`dot update` and resolves dependencies, node now comes back automatically if it ever goes missing. No hand-repair needed.

## Verification

- `bash -n` passes on `bin/dot` and `fnm/install.sh`
- No remaining `brew uninstall` / `SYMLINKS_NEEDED` / `/usr/local/bin/{node,npm,npx,corepack}` references
- `ensure_sudo` still called at `bin/dot:347` for macOS defaults — no dangling helper
- Ran `dot update` end to end: node survived at `26.5.0`, the "Removing in favor of FNM version" step is gone from the output, `pi` → `0.82.1`, `mongosh` → `2.9.2`, `brew missing` clean

## Note

The legacy `/usr/local/bin/{node,npm,npx,corepack}` symlinks still exist on already-provisioned machines. Nothing recreates them now, and `fnm/install.sh` removes them — but only on `dot install`, not `dot update`. Clear them early with `sudo rm -f /usr/local/bin/{node,npm,npx,corepack}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)