### PR TITLE
fix(zsh): survive brew upgrades of zsh-autocomplete

### DIFF
--- a/.changeset/plain-pandas-shave.md
+++ b/.changeset/plain-pandas-shave.md
@@ -1,0 +1,5 @@
+---
+'tk-dotfiles': patch
+---
+
+Add `$PNPM_HOME/bin` to `$PATH` so shims from pnpm global installs resolve, and drop the `pi-coding-agent` formula from the Brewfile. `pi-coding-agent` is now installed via pnpm rather than Homebrew; the install itself stays manual.

--- a/.changeset/quiet-shells-recover.md
+++ b/.changeset/quiet-shells-recover.md
@@ -1,0 +1,5 @@
+---
+'tk-dotfiles': patch
+---
+
+Keep running shells working when Homebrew upgrades `zsh-autocomplete`. The plugin pins its `~autocomplete` named directory to a versioned Cellar path at load time, so `brew upgrade` deletes that path out from under already-open shells and the deferred autoload of `z-async` fails on every line redraw (`.autocomplete:async:complete:61: z-async: function definition file not found`). A `precmd` hook now notices the dead directory and repoints `fpath` at `$HOMEBREW_PREFIX/share/zsh-autocomplete`, a stable directory of symlinks rather than a versioned one, so a repaired shell is also immune to later upgrades.

--- a/Brewfile
+++ b/Brewfile
@@ -25,7 +25,6 @@ brew 'just' # Task runner
 brew 'libgit2' # C library of Git core methods that is re-entrant and linkable
 brew 'mas' # CLI for installing app from Mac App Store
 brew 'openssl' # Cryptography and SSL/TLS Toolkit
-brew 'pi-coding-agent' # Customizable agent harness
 brew 'postgresql', restart_service: false # SQL database (manual start: brew services start postgresql)
 brew 'pyenv' # Python virtual env
 brew 'readline' # Library for command-line editing

--- a/zsh/path.zsh
+++ b/zsh/path.zsh
@@ -6,6 +6,12 @@ case ":$PATH:" in
 esac
 # pnpm end
 
+# Some pnpm-installed packages (e.g. pi-coding-agent) put their shim in
+# $PNPM_HOME/bin rather than $PNPM_HOME. `typeset -U PATH` keeps this
+# idempotent across re-sources. Kept outside the `# pnpm` markers above so
+# pnpm's own installer can rewrite that block without clobbering this.
+export PATH="$PNPM_HOME/bin:$PATH"
+
 # bun
 case ":$PATH:" in
   *":$HOME/.bun/bin:"*) ;;

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -94,23 +94,24 @@ if type brew &>/dev/null; then
 fi
 
 # Load zsh plugins from Homebrew (check existence before sourcing)
-[[ -f "$HOMEBREW_PREFIX/share/zsh-autocomplete/zsh-autocomplete.plugin.zsh" ]] && \
+if [[ -f "$HOMEBREW_PREFIX/share/zsh-autocomplete/zsh-autocomplete.plugin.zsh" ]]; then
   source "$HOMEBREW_PREFIX/share/zsh-autocomplete/zsh-autocomplete.plugin.zsh"
 
-# zsh-autocomplete pins ~autocomplete to a versioned Cellar dir. `brew upgrade`
-# deletes it under running shells, so autoloading z-async fails on every
-# keystroke. Repoint fpath at the new install instead.
-# ponytail: keeps already-loaded functions from the old version; run `exec zsh`
-# if a release ever changes the z-async interface.
-_autocomplete_repair_fpath() {
-  [[ -d ~autocomplete ]] && return
-  local dir=$HOMEBREW_PREFIX/share/zsh-autocomplete
-  [[ -d $dir ]] || return
-  fpath=( $dir/z-async $dir/Completions ${fpath[@]:#*/zsh-autocomplete/*} )
-  hash -d autocomplete=$dir zsh-autocomplete=$dir
-}
-autoload -Uz add-zsh-hook
-add-zsh-hook precmd _autocomplete_repair_fpath
+  # zsh-autocomplete pins ~autocomplete to a versioned Cellar dir. `brew upgrade`
+  # deletes it under running shells, so autoloading z-async fails on every
+  # keystroke. Repoint fpath at the new install instead.
+  # Caveat: keeps already-loaded functions from the old version; run `exec zsh`
+  # if a release ever changes the z-async interface.
+  _autocomplete_repair_fpath() {
+    [[ -d ~autocomplete ]] && return
+    local dir=$HOMEBREW_PREFIX/share/zsh-autocomplete
+    [[ -d $dir ]] || return
+    fpath=( $dir/z-async $dir/Completions ${fpath[@]:#*/zsh-autocomplete/*} )
+    hash -d autocomplete=$dir zsh-autocomplete=$dir
+  }
+  autoload -Uz add-zsh-hook
+  add-zsh-hook precmd _autocomplete_repair_fpath
+fi
 
 [[ -f "$HOMEBREW_PREFIX/share/zsh-autosuggestions/zsh-autosuggestions.zsh" ]] && \
   source "$HOMEBREW_PREFIX/share/zsh-autosuggestions/zsh-autosuggestions.zsh"

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -97,6 +97,21 @@ fi
 [[ -f "$HOMEBREW_PREFIX/share/zsh-autocomplete/zsh-autocomplete.plugin.zsh" ]] && \
   source "$HOMEBREW_PREFIX/share/zsh-autocomplete/zsh-autocomplete.plugin.zsh"
 
+# zsh-autocomplete pins ~autocomplete to a versioned Cellar dir. `brew upgrade`
+# deletes it under running shells, so autoloading z-async fails on every
+# keystroke. Repoint fpath at the new install instead.
+# ponytail: keeps already-loaded functions from the old version; run `exec zsh`
+# if a release ever changes the z-async interface.
+_autocomplete_repair_fpath() {
+  [[ -d ~autocomplete ]] && return
+  local dir=$HOMEBREW_PREFIX/share/zsh-autocomplete
+  [[ -d $dir ]] || return
+  fpath=( $dir/z-async $dir/Completions ${fpath[@]:#*/zsh-autocomplete/*} )
+  hash -d autocomplete=$dir zsh-autocomplete=$dir
+}
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _autocomplete_repair_fpath
+
 [[ -f "$HOMEBREW_PREFIX/share/zsh-autosuggestions/zsh-autosuggestions.zsh" ]] && \
   source "$HOMEBREW_PREFIX/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
 


### PR DESCRIPTION
## Problem

`zsh-autocomplete` pins its `~autocomplete` named directory to a **versioned** Cellar path when the plugin is sourced:

```zsh
local basedir=${${(%):-%x}:P:h}          # → .../Cellar/zsh-autocomplete/<version>/share/zsh-autocomplete
hash -d autocomplete=$basedir
typeset -gU FPATH fpath=( ~autocomplete/z-async $fpath[@] )
builtin autoload -Uz z-async
```

`brew upgrade` deletes that directory out from under already-running shells. `z-async` is autoloaded lazily and called from the `line-pre-redraw` hook, so every keystroke prints:

```
.autocomplete:async:complete:61: z-async: function definition file not found
```

Hit today when `26.08.03` → `26.08.04` landed mid-session. Restarting the shell fixes it, which is why it looks intermittent.

## Fix

A `precmd` hook notices the dead directory and repoints `fpath` at `$HOMEBREW_PREFIX/share/zsh-autocomplete` — a real directory of symlinks, not a versioned path — so a repaired shell stops caring about future upgrades entirely.

Deliberately not `exec zsh`: that would silently kill background jobs. It keeps the already-loaded functions from the old version, which is only a problem if a release changes the `z-async` interface; the comment says so.

## Verification

Simulated an upgrade in a live shell by pointing `~autocomplete` at the deleted `26.08.03` path:

- before the hook: `z-async: function definition file not found`
- after the hook: `Usage: z-async <command> [args]`
- calling it twice is a no-op; the happy path is one `stat` per prompt

## Notes

Stacked on #53 — that branch has an uncommitted `Brewfile` change locally that blocked branching from `main`. Should retarget to `main` automatically once #53 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)