### PR TITLE
chore(zsh): move pi-coding-agent to pnpm and put its shim on $PATH

### DIFF
--- a/.changeset/plain-pandas-shave.md
+++ b/.changeset/plain-pandas-shave.md
@@ -1,0 +1,5 @@
+---
+'tk-dotfiles': patch
+---
+
+Add `$PNPM_HOME/bin` to `$PATH` so shims from pnpm global installs resolve, and drop the `pi-coding-agent` formula from the Brewfile. `pi-coding-agent` is now installed via pnpm rather than Homebrew; the install itself stays manual.

--- a/Brewfile
+++ b/Brewfile
@@ -25,7 +25,6 @@ brew 'just' # Task runner
 brew 'libgit2' # C library of Git core methods that is re-entrant and linkable
 brew 'mas' # CLI for installing app from Mac App Store
 brew 'openssl' # Cryptography and SSL/TLS Toolkit
-brew 'pi-coding-agent' # Customizable agent harness
 brew 'postgresql', restart_service: false # SQL database (manual start: brew services start postgresql)
 brew 'pyenv' # Python virtual env
 brew 'readline' # Library for command-line editing

--- a/zsh/path.zsh
+++ b/zsh/path.zsh
@@ -6,6 +6,12 @@ case ":$PATH:" in
 esac
 # pnpm end
 
+# Some pnpm-installed packages (e.g. pi-coding-agent) put their shim in
+# $PNPM_HOME/bin rather than $PNPM_HOME. `typeset -U PATH` keeps this
+# idempotent across re-sources. Kept outside the `# pnpm` markers above so
+# pnpm's own installer can rewrite that block without clobbering this.
+export PATH="$PNPM_HOME/bin:$PATH"
+
 # bun
 case ":$PATH:" in
   *":$HOME/.bun/bin:"*) ;;


### PR DESCRIPTION
`pi` stopped resolving after switching `pi-coding-agent` off Homebrew. The pnpm global install puts its shim in `$PNPM_HOME/bin`, but `zsh/path.zsh` only had `$PNPM_HOME` on `$PATH` — so the binary existed and nothing could find it.

Adds the `/bin` entry alongside the existing pnpm block in `zsh/path.zsh`, and drops the now-unused `pi-coding-agent` formula from the Brewfile.

Verified in a fresh interactive shell — `pi` resolves, and the FNM shim is still first on `$PATH`:

```
$ zsh -i -c 'which pi; which node'
/Users/tk/Library/pnpm/bin/pi
/Users/tk/.local/state/fnm_multishells/56607_.../bin/node
```

Note that `commitlint` and `changeset-check` only trigger on PRs targeting `main`, so they don't run here. Ran commitlint locally against this commit — passes.

Stacked on #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)