### PR TITLE
fix(gsync): stop prompting to delete branches git can never delete

### DIFF
--- a/.changeset/loud-worktrees-survive.md
+++ b/.changeset/loud-worktrees-survive.md
@@ -1,0 +1,5 @@
+---
+'tk-dotfiles': patch
+---
+
+Stop `gsync` from prompting to delete branches that are checked out in a git worktree. `git branch -d/-D` refuses those with `error: cannot delete branch 'x' used by worktree at '...'`, so the prompt could only ever fail — and under `set -e` that failure aborted the rest of the run (pnpm install/build/test never happened). `gsync` now reads `git worktree list --porcelain` and skips such branches with the worktree path in the message.

--- a/bin/gsync
+++ b/bin/gsync
@@ -19,6 +19,9 @@ fi
 # Find local branches with no matching remote branch
 remote_branches=$(git branch -r | grep -v HEAD | sed 's|^[^/]*/||' | sort -u)
 mapfile -t local_branches < <(git branch --format '%(refname:short)')
+# branch<TAB>worktree path for every branch checked out in a worktree
+worktree_branches=$(git worktree list --porcelain |
+  awk '/^worktree /{p=$2} /^branch /{sub("refs/heads/","",$2); print $2"\t"p}')
 stale_branches=()
 
 for branch in "${local_branches[@]}"; do
@@ -40,6 +43,13 @@ if [[ ${#stale_branches[@]} -gt 0 ]]; then
   for branch in "${stale_branches[@]}"; do
     if [[ "$branch" == "$current_branch" ]]; then
       echo "  ⚠ $branch (skipped - currently checked out)"
+      continue
+    fi
+
+    # git refuses to delete a branch checked out in a worktree
+    worktree_path=$(awk -v b="$branch" -F'\t' '$1 == b { print $2 }' <<<"$worktree_branches")
+    if [[ -n "$worktree_path" ]]; then
+      echo "  ⚠ $branch (skipped - checked out in worktree at $worktree_path)"
       continue
     fi
 


### PR DESCRIPTION
`gsync` kept offering to delete branches that live in a git worktree, and the delete always failed:

```
✗ babysit/pr6 cannot be safely deleted (not fully merged)
  Force delete? [y/N] y
error: cannot delete branch 'babysit/pr6' used by worktree at '/private/tmp/pi-harness-pr6'
```

git refuses to delete a branch a worktree has checked out, so that prompt could only ever fail — and under `set -e` the failure aborted the rest of the run, so the pnpm install/build/test step never happened.

`gsync` now reads `git worktree list --porcelain` up front and skips those branches, naming the worktree that holds them:

```
⚠ babysit/pr6 (skipped - checked out in worktree at /private/tmp/pi-harness-pr6)
```

Verified by adding a real worktree in this repo, running `bin/gsync`, and confirming the branch was skipped instead of prompted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)