### PR TITLE
fix(ci): tag releases and create GitHub Releases

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,6 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
+  "privatePackages": { "version": true, "tag": true },
   "fixed": [],
   "linked": [],
   "access": "restricted",

--- a/.changeset/tidy-lions-tag.md
+++ b/.changeset/tidy-lions-tag.md
@@ -1,0 +1,5 @@
+---
+'tk-dotfiles': patch
+---
+
+Fix release CI so versions are actually tagged and published as GitHub Releases: the Release workflow now runs `changeset tag` as its publish step (with full git history so existing tags are detected), and changesets is configured to tag this private package.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          # Need full history + tags so `changeset tag` skips versions already tagged
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -36,6 +39,9 @@ jobs:
         uses: changesets/action@v1
         with:
           version: pnpm run version
+          # `changeset tag` pushes a vX.Y.Z git tag; the action then cuts a
+          # GitHub Release from the matching CHANGELOG.md section
+          publish: pnpm run release
           commit: 'chore: version packages'
           title: 'chore: version packages'
         env:


### PR DESCRIPTION
## Problem

No versions appear in the repo's Releases panel, and `git tag` is empty despite 2.4.0 being versioned.

Two causes:

1. `.github/workflows/release.yml` passed no `publish` input to `changesets/action`, so the action only ever opened/merged version PRs — it never tagged or cut a release.
2. Even run manually, `changeset tag` silently no-ops here: the root package is `private: true` and changesets' `privatePackages.tag` defaults to `false`.

## Fix

- `publish: pnpm run release` (`changeset tag`) in the Release workflow — the action parses its `New tag:` output and creates a GitHub Release from the matching `CHANGELOG.md` section.
- `privatePackages: { version: true, tag: true }` in `.changeset/config.json`.
- `fetch-depth: 0` on checkout so already-existing tags are seen and skipped instead of re-created on every push to main.

## Verification

`pnpm release` locally now prints `🦋 New tag: v2.4.0` and creates the tag (deleted locally after the check — CI will create and push it). Previously it printed nothing. `pnpm format:check` passes.

First push to main after merge backfills `v2.4.0` plus its GitHub Release; subsequent version PRs tag on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)