### PR TITLE
fix(ci): read Node version from .node-version

### DIFF
--- a/.changeset/olive-pugs-repeat.md
+++ b/.changeset/olive-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+'tk-dotfiles': patch
+---
+
+Fix CI: read the Node version from `.node-version` instead of hardcoding Node 20, which is below the floor required by `@changesets/cli` v3 and `@commitlint` v21

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.node-version'
           cache: 'pnpm'
 
       - name: Install Dependencies

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.node-version'
           cache: 'pnpm'
 
       - name: Install Dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.node-version'
           cache: 'pnpm'
 
       - name: Install Dependencies


### PR DESCRIPTION
Fixes the release job failure on `main` after #60: [run 31647434704](https://github.com/akornmeier/dotfiles/actions/runs/31647434704/job/94284160129).

## Root cause

`@changesets/cli` v3 opens with:

```js
if (globalThis.process?.getBuiltinModule) {
  const { enableCompileCache } = globalThis.process.getBuiltinModule('node:module')
  enableCompileCache()
}
```

Its `engines` field is `^22.11 || ^24 || >=26`, and `@commitlint/*` v21 requires `>=22.12.0`. All three workflows hardcoded `node-version: 20`, so `pnpm run version` crashed with `TypeError: enableCompileCache is not a function`.

This passed pre-merge verification because `.node-version` pins `v22.14.0` and fnm supplies that locally — CI never read the file.

## Fix

Point `actions/setup-node` at `.node-version` in all three workflows instead of a hardcoded literal, so CI tracks the repo's pinned version and can't drift again:

- `release.yml`
- `commitlint.yml`
- `changeset-check.yml`

## Verification

Ran the exact command that failed in CI, on Node 22.14.0:

```
$ pnpm run version
🦋 changeset v3.0.0
All files have been updated. Review them and commit at your leisure
$ node -p "require('./package.json').version"
2.4.2
```

Local side effects reverted; only the workflow changes and a changeset ship here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)